### PR TITLE
Alternate storage for init extension variables

### DIFF
--- a/ecmd-core/capi/ecmdClientCapi.C
+++ b/ecmd-core/capi/ecmdClientCapi.C
@@ -252,7 +252,8 @@ uint32_t ecmdUnloadDll() {
 #endif
 
   /* Go reset all the extensions so they know we have been unloaded */
-  ecmdResetExtensionInitState();
+  ecmdResetExtensionInitStateHidden();
+  ecmdResetExtensionInitState(); // TODO remove ecmd 15
 
 #ifdef ECMD_STATIC_FUNCTIONS
   rc = dllUnloadDll();

--- a/ecmd-core/capi/ecmdUtils.C
+++ b/ecmd-core/capi/ecmdUtils.C
@@ -2480,6 +2480,27 @@ void ecmdResetExtensionInitState() {
 }
 
 /**
+ @brief Registers an extensions initstate pointer defect #18081
+ @param i_initState Pointer to initState static so it can be reset later
+ */
+static std::list<bool*> g_initPtrsHidden;
+void ecmdRegisterExtensionInitStateHidden(bool* i_initState) {
+  if (find(g_initPtrsHidden.begin(), g_initPtrsHidden.end(), i_initState) == g_initPtrsHidden.end()) {
+    g_initPtrsHidden.push_back(i_initState);
+  }
+}
+
+/**
+ @brief Reset Extension initstate pointer to uninitialized and remove from list
+*/
+void ecmdResetExtensionInitStateHidden() {
+  while (!g_initPtrsHidden.empty()) {
+    *(g_initPtrsHidden.front()) = false;
+    g_initPtrsHidden.pop_front();
+  }
+}
+
+/**
  @brief opens the groupscomdef parses the file
  @param i_filename file to open
  @param o_total_scomGroupRecord list of scomgroups that is returned

--- a/ecmd-core/capi/ecmdUtils.H
+++ b/ecmd-core/capi/ecmdUtils.H
@@ -195,6 +195,17 @@ void ecmdRegisterExtensionInitState(bool* i_initState);
 */
 void ecmdResetExtensionInitState();
 
+/**
+ @brief Registers an extensions initstate pointer defect #18081
+ @param i_initState Pointer to initState static so it can be reset later
+ */
+void ecmdRegisterExtensionInitStateHidden(bool* i_initState);
+
+/**
+ @brief Reset Extension initstate pointer to uninitialized and remove from list
+*/
+void ecmdResetExtensionInitStateHidden();
+
 
 #endif
 

--- a/ecmd-core/ext/fapi2/capi/fapi2ClientCapiInit.C
+++ b/ecmd-core/ext/fapi2/capi/fapi2ClientCapiInit.C
@@ -112,7 +112,7 @@ uint32_t fapi2InitExtension() {
 #endif /* ECMD_STATIC_FUNCTIONS */
 
   /* Now as part of defect 18081 we register to the core client that we have been initialized */
-  ecmdRegisterExtensionInitState(&fapi2Initialized);
+  ecmdRegisterExtensionInitStateHidden(&fapi2Initialized);
 
   if (rc) {
     std::string errorString;

--- a/ecmd-core/ext/template/capi/templateClientCapi.C
+++ b/ecmd-core/ext/template/capi/templateClientCapi.C
@@ -108,7 +108,7 @@ uint32_t templateInitExtension() {
 #endif /* ECMD_STATIC_FUNCTIONS */
 
   /* Now as part of defect 18081 we register to the core client that we have been initialized */
-  ecmdRegisterExtensionInitState(&templateInitialized);
+  ecmdRegisterExtensionInitStateHidden(&templateInitialized);
 
   if (rc) {
     std::string errorString;


### PR DESCRIPTION
Store init extension variables in an alternate container to
enable compatibility with previous eCMD version where extension
variables were statically linked into the executable.

Signed-off-by: Matt K. Light <mklight@us.ibm.com>