### PR TITLE
Remove std::shared_ptr<fapi2::ErrorInfo> creation for destructor access.

### DIFF
--- a/ecmd-core/ext/fapi2/capi/plat_utils.C
+++ b/ecmd-core/ext/fapi2/capi/plat_utils.C
@@ -59,8 +59,6 @@ extern int fppCallCount;
 extern bool ecmdDebugOutput;
 #endif
 
-std::shared_ptr<fapi2::ErrorInfo> l_ei(new fapi2::ErrorInfo());
-
 namespace fapi2
 {
     ///


### PR DESCRIPTION
This is interfering with Cronus. Undo this change when moving to
all shared objects.

Signed-off-by: Matt K. Light <mklight@us.ibm.com>