### PR TITLE
Serverupdateopenbmc410

### DIFF
--- a/dllNetwork/server/ServerFSIInstruction.C
+++ b/dllNetwork/server/ServerFSIInstruction.C
@@ -204,11 +204,14 @@ uint32_t ServerFSIInstruction::mbx_open(Handle** handle, InstructionStatus & o_s
   if(*handle != NULL)
     return rc;
 
-  const char * devices[3][2] = {
-    {"", ""},
-    {"/sys/devices/platform/fsi-master/slave@00:00/raw",
+  const uint32_t numPaths = 3;
+  const char * devices[3][3] = {
+    {"", "", ""},
+    {"/sys/devices/platform/gpio-fsi/fsi0/slave@00:00/raw",
+     "/sys/devices/platform/fsi-master/slave@00:00/raw",
      "/sys/bus/platform/devices/fsi-master/slave@00:00/raw"},
-    {"/sys/devices/platform/fsi-master/slave@00:00/hub@00/slave@01:00/raw",
+    {"/sys/devices/platform/gpio-fsi/fsi0/slave@00:00/00:00:00:0a/fsi1/slave@01:00/raw",
+     "/sys/devices/platform/fsi-master/slave@00:00/hub@00/slave@01:00/raw",
      "/sys/devices/hub@00/slave@01:00/raw"}};
 
   /* We need to open the device*/
@@ -233,7 +236,7 @@ uint32_t ServerFSIInstruction::mbx_open(Handle** handle, InstructionStatus & o_s
     return SERVER_INVALID_FSI_DEVICE;
   }
 
-  for (uint32_t l_try = 0; l_try < 2; l_try++) {
+  for (uint32_t l_try = 0; l_try < numPaths; l_try++) {
     /* Validate and adjust the device string for the device to open */
     snprintf(device, 100, devices[l_idx][l_try]);
 

--- a/dllNetwork/server/ServerGPIOInstruction.C
+++ b/dllNetwork/server/ServerGPIOInstruction.C
@@ -27,14 +27,14 @@ Handle * system_gpio_open(const char * device, int flags) { return NULL; }
 
 uint32_t ServerGPIOInstruction::gpio_open(Handle ** handle, InstructionStatus & o_status)
 {
-  uint32_t rc = 0;
+    uint32_t rc = 0;
 
-  char device[50];
-  char errstr[200];
+    char device[50];
+    char errstr[200];
 
-  /* already have a handle lets reuse it */
-  if(*handle != NULL)
-    return rc;
+    /* already have a handle lets reuse it */
+    if(*handle != NULL)
+      return rc;
 
     /* Open the device */
     if (flags & INSTRUCTION_FLAG_DEVSTR) {

--- a/dllNetwork/server/adals/adal_base.c
+++ b/dllNetwork/server/adals/adal_base.c
@@ -1,0 +1,57 @@
+//IBM_PROLOG_BEGIN_TAG
+/* 
+ * Copyright 2003,2017 IBM International Business Machines Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//IBM_PROLOG_END_TAG
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/utsname.h>
+#include "adal_base.h"
+
+bool adal_is_byte_swap_needed( ) {
+    struct utsname unameBuf;
+
+    char *str, *token, *prvToken, *saveptr;
+
+    int rc = uname(&unameBuf);
+    if ( rc ) return false;
+
+    // idx 1 < 4 return false, version is less than 4.10
+    // idx 1 > 4 return true, version is greater than 4.10
+    // idx 2 < 10 and idx 1 == 4 return false, version is less than 4.10
+    // idx 2 >= 10 and idx 1 == 4 return true, version is greater than 4.10
+    str = unameBuf.release;
+    for( int idx=1; ; idx++, str=NULL )
+    {
+        token = strtok_r( str, ".", &saveptr );
+        if ( token == NULL )
+            break;
+        if ( idx == 1 && atoi(token) < 4 )
+            return false;
+        else if ( idx == 1 && atoi(token) > 4 )
+            return true;
+        else if ( idx == 2 && atoi(token) < 10 && atoi(prvToken) == 4 )
+            return false;
+        else if ( idx == 2 && atoi(token) >= 10 && atoi(prvToken) == 4 )
+            return true;
+        else if ( idx > 2 )
+            break;
+        prvToken = token;
+    }
+    return false;
+}
+

--- a/dllNetwork/server/adals/adal_base_interfaces.h
+++ b/dllNetwork/server/adals/adal_base_interfaces.h
@@ -752,6 +752,10 @@ adal_t * adal_base_wait_get_adal_t(adal_wait_t * evt);
 int adal_base_lctl(adal_t * adal, int type);
 
 
+/* adal method to determine if a endian byte swap is needed */
+/* based on the openbmc version */
+bool adal_is_byte_swap_needed(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/dllNetwork/server/adals/scom/adal_scom.c
+++ b/dllNetwork/server/adals/scom/adal_scom.c
@@ -121,7 +121,7 @@ int adal_scom_close(adal_t * adal)
 
 ssize_t adal_scom_read(adal_t * adal, void * buf, uint64_t scom_address, unsigned long * status)
 {
-	int rc = 0, rc1 = 0;
+	int rc = 0;
 
 	if (scom_address & INDIRECT_SCOM_ADDR) {
 		uint64_t read_data;
@@ -142,14 +142,15 @@ ssize_t adal_scom_read(adal_t * adal, void * buf, uint64_t scom_address, unsigne
 		rc = read(adal->fd, buf, SCOM_DATA_LEN);
 	}
 
-	rc1 = adal_scom_get_register(adal, STATUS, status);
+        // ignore rc as status is checked later
+	adal_scom_get_register(adal, STATUS, status);
 
 	return rc;
 }
 
 ssize_t adal_scom_write(adal_t * adal, void * buf, uint64_t scom_address,  unsigned long * status)
 {
-	int rc = 0, rc1 = 0;
+	int rc = 0;
 
 	if (scom_address & INDIRECT_SCOM_ADDR) {
 		uint64_t data;
@@ -179,7 +180,8 @@ ssize_t adal_scom_write(adal_t * adal, void * buf, uint64_t scom_address,  unsig
 		rc = write(adal->fd, buf, SCOM_DATA_LEN);
 	}
 
-	rc1 = adal_scom_get_register(adal, STATUS, status);
+        // ignore rc as status is checked later
+	adal_scom_get_register(adal, STATUS, status);
 
 	return rc;
 }

--- a/dllNetwork/server/makefile
+++ b/dllNetwork/server/makefile
@@ -11,7 +11,7 @@ include ../../makefile.base
 TARGET       := server1p
 CXXFLAGS     += -I ${ECMD_ROOT}/ecmd-core/capi -I ${ECMD_ROOT}/ecmd-core/dll -I${SRCPATH}
 CXXFLAGS     += -Iadals -Iadals/scom -Iadals/scan -Iadals/sbefifo -Iadals/mbx -Iadals/iic_master
-VPATH        := ${VPATH}:${ECMD_ROOT}/ecmd-core/capi:${ECMD_ROOT}/ecmd-core/dll:${SRCPATH}:adals/scom:adals/scan:adals/sbefifo:adals/mbx:adals/iic_master
+VPATH        := ${VPATH}:${ECMD_ROOT}/ecmd-core/capi:${ECMD_ROOT}/ecmd-core/dll:${SRCPATH}:adals:adals/scom:adals/scan:adals/sbefifo:adals/mbx:adals/iic_master
 
 # *****************************************************************************
 # Setup all the files going into the build
@@ -59,7 +59,8 @@ TGT_SOURCE += ServerSBEFIFOInstruction.C
 TGT_SOURCE += SBEFIFOInstruction.C
 TGT_SOURCE += server1p.C
 
-TGT_SOURCE_C := adal_scom.c
+TGT_SOURCE_C := adal_base.c
+TGT_SOURCE_C += adal_scom.c
 TGT_SOURCE_C += adal_scan.c
 TGT_SOURCE_C += adal_sbefifo.c
 TGT_SOURCE_C += adal_mbx.c


### PR DESCRIPTION
Cleaning up compiler warnings
Handling new device paths for OpenFSI 
Handling endianness byte swaps for OpenBMC 4.10 or higher when accessing the raw device with regards to status register checking, sbefifo read/writing, and scom read/write