### PR TITLE
Full set of fixes for builds with no extentions

### DIFF
--- a/config.py
+++ b/config.py
@@ -898,7 +898,7 @@ if (DISTRO_OVERRIDE != ""):
 # Write our optional extension makefile.config includes
 # This allows you to add values to variables defined above
 config.write("# Optionally include any extension specific makefile.config overrides\n")
-for ext in sorted(EXTENSIONS.split(" ")):
+for ext in sorted(EXTENSIONS.split()):
     config.write("-include %s\n" % os.path.join(buildvars["EXT_" + ext + "_PATH"], "makefile.config")) 
 
 config.close()

--- a/ecmd-core/cmd/createEcmdHelp.pl
+++ b/ecmd-core/cmd/createEcmdHelp.pl
@@ -26,9 +26,6 @@ chomp($pwd = `cd $pwd;pwd`);  # Get to where this script resides
 my @extensions;
 if ($ENV{"EXTENSIONS"} ne "") {
   @extensions = sort split(/\s+/, $ENV{"EXTENSIONS"})
-} else {
-  # Error
-  die "EXTENSIONS not set";
 }
 
 # Add the common command onto the front

--- a/mkscripts/makeext.py
+++ b/mkscripts/makeext.py
@@ -16,10 +16,7 @@ import errno
 # -----------------------
 if (sys.argv[1] == "cmd"):
   # Pull EXT_CMD out of the environment
-  extlist = os.environ["EXT_CMD"].split(" ")
-  # EXT_CMD could be empty, but splitting on " " will create 1 entry
-  # Filter out any empty entries
-  extlist = filter(None, extlist)
+  extlist = os.environ["EXT_CMD"].split()
 
   # Open our file and start writing
   extfile = open(os.environ["SRCPATH"] + "/ecmdExtInterpreter.C", 'w')
@@ -74,11 +71,11 @@ if (sys.argv[1] == "doxygen"):
   # Pull the right EXT list out of the env based on arg2
   extlist = list()
   if (sys.argv[2] == "capi"):
-    extlist = os.environ["EXT_CAPI"].split(" ")
+    extlist = os.environ["EXT_CAPI"].split()
   elif (sys.argv[2] == "perlapi"):
-    extlist = os.environ["EXT_PERLAPI"].split(" ")
+    extlist = os.environ["EXT_PERLAPI"].split()
   elif (sys.argv[2] == "pyapi"):
-    extlist = os.environ["EXT_PYAPI"].split(" ")
+    extlist = os.environ["EXT_PYAPI"].split()
   else:
     print("Unknown API \"%s\" passed in!  Exiting.." % (sys.argv[2]))
     exit(1)
@@ -112,7 +109,7 @@ if (sys.argv[1] == "doxygen"):
 if (sys.argv[1] == "pyapi"):
   
   # Pull EXT_PYAPI out of the environment
-  extlist = os.environ["EXT_PYAPI"].split(" ")
+  extlist = os.environ["EXT_PYAPI"].split()
 
   # Open our file and start writing
   extfile = open(os.environ["SRCPATH"] + "/ecmdExtPyIncludes.i", 'w')
@@ -153,7 +150,7 @@ if (sys.argv[1] == "pyapi"):
 if (sys.argv[1] == "perlapi"):
   
   # Pull EXT_PERLAPI out of the environment
-  extlist = os.environ["EXT_PERLAPI"].split(" ")
+  extlist = os.environ["EXT_PERLAPI"].split()
 
   # Open our file and start writing
   extfile = open(os.environ["SRCPATH"] + "/ecmdExtPerlIncludes.i", 'w')


### PR DESCRIPTION
- Changed to python split() with no args, that handles whitespace
  better than split(" ")
- Support for createEcmdHelp.pl to be called with no extensions
  defined
- Tested cleanly with a number of different extension combos

Signed-off-by: Jason Albert <albertj@us.ibm.com>