### PR TITLE
Fix hint in configure error message

### DIFF
--- a/config.py
+++ b/config.py
@@ -857,7 +857,7 @@ if (not args.without_swig):
             verNoFloat = (int(versplit[0]) * 1000000) + (int(versplit[1]) * 1000) + int(versplit[2])
             if (verNoFloat < 2000011):
                 print("ERROR: Your swig version %s is less than the minimum version of 2.0.11" % version)
-                print("ERROR: Please run again and specify a differen swig executable or disable swig with --no-swig")
+                print("ERROR: Please run again and specify a differen swig executable or disable swig with --without-swig")
                 sys.exit(1)
 
 ##################################################


### PR DESCRIPTION
When an invalid version of swig is found, config.py exits with an
error and suggests running with "--no-swig". This is incorrect and is
not a valid option. The correct option is "--without-swig", so print
this in the error message instead.

Signed-off-by: Ryan King rpking@us.ibm.com