### PR TITLE
use correct suffix for loading ppc64le shared objects

### DIFF
--- a/ecmd-core/ext/fapi2/capi/hwp_executor.C
+++ b/ecmd-core/ext/fapi2/capi/hwp_executor.C
@@ -48,7 +48,11 @@ namespace fapi2plat
 #ifdef __linux__
 #ifdef _LP64
 #ifdef __powerpc__
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        std::string tmp = (i_libName + "_ppc64le.so");
+#else
         std::string tmp = (i_libName + "_ppc64.so");
+#endif
 #else
         std::string tmp = (i_libName + "_x86_64.so");
 #endif // end _LP64


### PR DESCRIPTION
Signed-off-by: Matt K. Light <mklight@us.ibm.com>