### PR TITLE
Make Python module compatible with both Python 2 and 3

### DIFF
--- a/ecmd-core/bin/ecmdsetup.pl
+++ b/ecmd-core/bin/ecmdsetup.pl
@@ -423,6 +423,14 @@ sub main {
   }
 
   ##########################################################################
+  # Add python directory to PYTHONPATH
+  #
+  if (!$cleanup) {
+    $ENV{"PYTHONPATH"} = $releasePath . "/" . $arch . "/python:" . $ENV{"PYTHONPATH"};
+    $modified{"PYTHONPATH"} = 1;
+  }
+
+  ##########################################################################
   # Updates setup scripts if release changed
   # All we need to do is resource the setup scripts
   #

--- a/ecmd-core/pyapi/init/__init__.py
+++ b/ecmd-core/pyapi/init/__init__.py
@@ -1,2 +1,7 @@
-# Quick init script so we can link from site-packages
-from ecmd import *
+# import the right SWIG module depending on Python version
+from sys import version_info
+if version_info[0] >= 3:
+    from .python3 import *
+else:
+    from .python2 import *
+del version_info

--- a/ecmd-core/pyapi/init/ecmd-deprecation-warning.py
+++ b/ecmd-core/pyapi/init/ecmd-deprecation-warning.py
@@ -1,0 +1,19 @@
+from __future__ import print_function
+
+print("\n\n#######################################################################################################")
+print("# Importing ecmd from the python2 or python3 directory is deprecated!                                 #")
+print("# There is a common python directory for both 2 and 3 now, and ecmdsetup sets up PYTHONPATH,          #")
+print("# so no PYTHONPATH modification should be necessary on your part.                                     #")
+print("# The python2 and python3 dirs will vanish soon, so please update your wrappers/boilerplate/etc.      #")
+print("#######################################################################################################\n\n")
+
+# this is a convoluted way to say "from this specific package directory import *"
+import os, imp, sys
+ecmd_path = os.path.join(os.path.dirname(__file__), "..", "python")
+sys.path.insert(0, ecmd_path)
+ecmd_indirect = imp.load_module("ecmd", None, os.path.join(ecmd_path, "ecmd"), ("", "", imp.PKG_DIRECTORY))
+for name in dir(ecmd_indirect):
+    if not name.startswith("_"):
+       globals()[name] = getattr(ecmd_indirect, name)
+del sys.path[0]
+del os, imp, sys, ecmd_path, ecmd_indirect

--- a/ecmd-core/pyapi/makefile
+++ b/ecmd-core/pyapi/makefile
@@ -72,14 +72,14 @@ build: ${SO_TARGET}
 install: ${VERINSTALL}
 
 pyapi_install:
-	@echo "Creating ${TARGET_ARCH}/${PYTHON_NAME} dir ..."
-	@mkdir -p ${INSTALL_PATH}/${TARGET_ARCH}/${PYTHON_NAME}
+	@echo "Creating ${TARGET_ARCH}/python/ecmd/${PYTHON_NAME} dir ..."
+	@mkdir -p ${INSTALL_PATH}/${TARGET_ARCH}/python/ecmd/${PYTHON_NAME}
 	@echo " "
 
-	@echo "Installing eCMD Python API ${INSTALL_PATH}/${TARGET_ARCH}/${PYTHON_NAME}.."
-	cp ${OUTPY}/${PY_TARGET} ${INSTALL_PATH}/${TARGET_ARCH}/${PYTHON_NAME}/.
-	cp ${OUTPY}/${SO_TARGET} ${INSTALL_PATH}/${TARGET_ARCH}/${PYTHON_NAME}/.
-	cp ${ECMD_CORE}/pyapi/init/__init__.py ${INSTALL_PATH}/${TARGET_ARCH}/${PYTHON_NAME}/.
+	@echo "Installing eCMD Python API ${INSTALL_PATH}/${TARGET_ARCH}/python/ecmd/${PYTHON_NAME}.."
+	cp ${OUTPY}/${PY_TARGET} ${INSTALL_PATH}/${TARGET_ARCH}/python/ecmd/${PYTHON_NAME}/__init__.py
+	cp ${OUTPY}/${SO_TARGET} ${INSTALL_PATH}/${TARGET_ARCH}/python/ecmd/${PYTHON_NAME}/.
+	cp ${ECMD_CORE}/pyapi/init/__init__.py ${INSTALL_PATH}/${TARGET_ARCH}/python/ecmd/.
 
 test:
 	@echo "***** If you see python load errors this build of the python module is invalid ****"

--- a/ecmd-core/pyapi/makefile
+++ b/ecmd-core/pyapi/makefile
@@ -80,6 +80,11 @@ pyapi_install:
 	cp ${OUTPY}/${PY_TARGET} ${INSTALL_PATH}/${TARGET_ARCH}/python/ecmd/${PYTHON_NAME}/__init__.py
 	cp ${OUTPY}/${SO_TARGET} ${INSTALL_PATH}/${TARGET_ARCH}/python/ecmd/${PYTHON_NAME}/.
 	cp ${ECMD_CORE}/pyapi/init/__init__.py ${INSTALL_PATH}/${TARGET_ARCH}/python/ecmd/.
+	@echo " "
+
+	@echo "Creating ${TARGET_ARCH}/${PYTHON_NAME} dir and adding deprecation warning ..."
+	@mkdir -p ${INSTALL_PATH}/${TARGET_ARCH}/${PYTHON_NAME}
+	cp ${ECMD_CORE}/pyapi/init/ecmd-deprecation-warning.py ${INSTALL_PATH}/${TARGET_ARCH}/${PYTHON_NAME}/ecmd.py
 
 test:
 	@echo "***** If you see python load errors this build of the python module is invalid ****"


### PR DESCRIPTION
Add a small wrapper that will defer to the appropriate SWIG module depending on Python version. This way the module can be found via PYTHONPATH and successfully imported by both Python versions. ecmdsetup is changed accordingly to set up PYTHONPATH.
Also change the legacy python2 and python3 modules to emit a warning message on import before deferring to the new module, to encourage users to switch.