### PR TITLE
Added path of module being loaded to sys.path

### DIFF
--- a/ecmd-core/pyapi/init/__init__.py
+++ b/ecmd-core/pyapi/init/__init__.py
@@ -1,10 +1,11 @@
 # import the right SWIG module depending on Python version
 from sys import version_info
-import sys, os
+from sys import path as sys_path
+from os import path as os_path
 if version_info[0] >= 3:
-    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "python3"))
+    sys_path.insert(0, os_path.join(os_path.dirname(__file__), "python3"))
     from .python3 import *
 else:
-    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "python2"))
+    sys_path.insert(0, os_path.join(os_path.dirname(__file__), "python2"))
     from .python2 import *
-del sys, os, version_info
+del sys_path, os_path, version_info

--- a/ecmd-core/pyapi/init/__init__.py
+++ b/ecmd-core/pyapi/init/__init__.py
@@ -1,7 +1,10 @@
 # import the right SWIG module depending on Python version
 from sys import version_info
+import sys, os
 if version_info[0] >= 3:
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "python3"))
     from .python3 import *
 else:
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "python2"))
     from .python2 import *
-del version_info
+del sys, os, version_info


### PR DESCRIPTION
- If path not added, the import would fail with:
  ImportError: No module named _ecmd
  This was because it couldn't find the .so

Signed-off-by: Jason Albert <albertj@us.ibm.com>