### PR TITLE
Removed return statement from ecmdsetup.pl

### DIFF
--- a/ecmd-core/bin/ecmdsetup.pl
+++ b/ecmd-core/bin/ecmdsetup.pl
@@ -93,10 +93,6 @@ my $cleanup = 0;  # Call only cleanup on the plugins to remove anything they mig
 # Call the main function, then add the rc from that to the output
 #
 $rc = main();
-# Yet again, csh sucks and doesn't have a return value.  They will have to go without
-if ($shell eq "ksh") {
-  printf("return $rc;");
-}
 exit($rc);
 
 sub main {


### PR DESCRIPTION
- The inline return that was at the end of the return string was
  causing anything after that line in an alias/function to not
  be executed

Signed-off-by: Jason Albert <albertj@us.ibm.com>