### PR TITLE
Improved return code handling in ecmdsetup.pl

### DIFF
--- a/ecmd-core/bin/ecmdsetup.pl
+++ b/ecmd-core/bin/ecmdsetup.pl
@@ -508,6 +508,7 @@ sub help {
   ecmd_print("[copylocal] - Copy the \$ECMD_EXE and \$ECMD_DLL_FILE to /tmp/\$ECMD_TARGET/");
   ecmd_print("[cleanup] - Remove all eCMD and Plugin settings from environment");
   ecmd_print("[quiet] - Disables status output");
+  ecmd_print("[noret] - Removes return code from variable set string");
   ecmd_print("<plugin options> - anything else passed into the script is passed onto the plugin");
   ecmd_print("-h - this help text");
 }

--- a/ecmd-core/bin/ecmdsetup.pl
+++ b/ecmd-core/bin/ecmdsetup.pl
@@ -88,13 +88,14 @@ my $shortcut = 0;
 my $singleInstall = 1;  # Assume it's a single install and then disprove it by looking at the path
 my $copyLocal = 0;  # Does the user want ECMD_EXE and ECMD_DLL_FILE copied to /tmp and run from there?
 my $cleanup = 0;  # Call only cleanup on the plugins to remove anything they might have put out there.
+my $noret = 0; # Don't insert a return statement into output string
 
 #####################################################
 # Call the main function, then add the rc from that to the output
 #
 $rc = main();
 # Yet again, csh sucks and doesn't have a return value.  They will have to go without
-if ($shell eq "ksh") {
+if ($shell eq "ksh" && !$noret) {
   printf("return $rc;");
 }
 exit($rc);
@@ -207,6 +208,9 @@ sub main {
 	splice(@ARGV,$x,1);  # Remove so plugin doesn't see it
     } elsif ($ARGV[$x] eq "quiet") {
 	$ecmdsetup::quiet = 1;
+	splice(@ARGV,$x,1);  # Remove so plugin doesn't see it
+    } elsif ($ARGV[$x] eq "noret") {
+	$noret = 1;
 	splice(@ARGV,$x,1);  # Remove so plugin doesn't see it
     } else {
       # We have to walk the array here because the splice shortens up the array


### PR DESCRIPTION
- The inline return that was at the end of the return string was
  causing anything after that line in an alias/function to not
  be executed
  It can now be optionally disabled with "noret"

Signed-off-by: Jason Albert <albertj@us.ibm.com>