### PR TITLE
Update to allow i2c reset functionality

### DIFF
--- a/dllNetwork/server/CronusRc.H
+++ b/dllNetwork/server/CronusRc.H
@@ -185,6 +185,9 @@
 #define SERVER_I2C_SCAN_WRITE_FAIL                     (ECMD_ERR_CRONUS | 0x401959)
 #define SERVER_I2C_SCAN_READ_FAIL                      (ECMD_ERR_CRONUS | 0x40195A)
 #define SERVER_I2C_USE_FSP_FAIL                        (ECMD_ERR_CRONUS | 0x40195B)
+#define SERVER_I2C_RESET_FULL_FAIL                     (ECMD_ERR_CRONUS | 0x40195C)
+#define SERVER_I2C_RESET_LIGHT_FAIL                    (ECMD_ERR_CRONUS | 0x40195D)
+#define SERVER_I2C_RESET_SUCCESS                       (ECMD_ERR_CRONUS | 0x40195E)
 
 #define SERVER_GPIO_GENERAL_ERROR                      (ECMD_ERR_CRONUS | 0x401960)
 #define SERVER_GPIO_OPEN_FAIL                          (ECMD_ERR_CRONUS | 0x401961)

--- a/dllNetwork/server/FSIInstruction.H
+++ b/dllNetwork/server/FSIInstruction.H
@@ -288,6 +288,7 @@ bits 0:3  bits 4:7,            bits 8:15,     bits 16:23,    bits 24:31 </pre>
     virtual ssize_t mbx_get_register(Handle * i_handle, ecmdDataBufferBase & o_data, InstructionStatus & o_status) { return -1; }
     virtual ssize_t gp_reg_get(Handle * i_handle, ecmdDataBufferBase & o_data, InstructionStatus & o_status) { return -1; }
     virtual ssize_t sbefifo_get_register(Handle * i_handle, ecmdDataBufferBase & o_data, InstructionStatus & o_status) { return -1; }
+    virtual ssize_t iic_get_register(Handle * i_handle, ecmdDataBufferBase & o_data, InstructionStatus & o_status) { return -1; }
 
     virtual ssize_t scan_set_register(Handle * i_handle, InstructionStatus & o_status) { return -1; }
     virtual ssize_t scom_set_register(Handle * i_handle, InstructionStatus & o_status) { return -1; }
@@ -295,6 +296,7 @@ bits 0:3  bits 4:7,            bits 8:15,     bits 16:23,    bits 24:31 </pre>
     virtual ssize_t mbx_set_register(Handle * i_handle, InstructionStatus & o_status) { return -1; }
     virtual ssize_t gp_reg_set(Handle * i_handle, InstructionStatus & o_status) { return -1; }
     virtual ssize_t sbefifo_set_register(Handle * i_handle, InstructionStatus & o_status) { return -1; }
+    virtual ssize_t iic_set_register(Handle * i_handle, InstructionStatus & o_status) { return -1; }
 };
 
 #endif // _FSIInstruction_H

--- a/dllNetwork/server/I2CInstruction.H
+++ b/dllNetwork/server/I2CInstruction.H
@@ -256,6 +256,7 @@ bits 0:3  bits 4:7,      bits 8:15,     bits 16:23,      bits 24:31 </pre>
     virtual uint32_t iic_config_device_offset(Handle * i_handle, InstructionStatus & o_status) { return -1; }
     virtual ssize_t iic_read(Handle * i_handle, ecmdDataBufferBase & o_data, InstructionStatus & o_status) { return -1; }
     virtual ssize_t iic_write(Handle * i_handle, InstructionStatus & o_status) { return -1; }
+    virtual uint32_t iic_reset(Handle * i_handle, int type) { return -1; }
 };
 
 #endif // _I2CINSTRUCTION_H

--- a/dllNetwork/server/Instruction.C
+++ b/dllNetwork/server/Instruction.C
@@ -147,6 +147,10 @@ std::string InstructionCommandToString(Instruction::InstructionCommand i_command
       return "I2CWRITE";
     case Instruction::I2CREAD:
       return "I2CREAD";
+    case Instruction::I2CRESETLIGHT:
+      return "I2CRESETLIGHT";
+    case Instruction::I2CRESETFULL:
+      return "I2CRESETFULL";
     case Instruction::GPIO_CONFIGPIN:
       return "GPIO_CONFIGPIN";
     case Instruction::GPIO_READPIN:
@@ -253,6 +257,8 @@ std::string InstructionCommandToString(Instruction::InstructionCommand i_command
       return "PNORPUT";
     case Instruction::QUERYSP:
       return "QUERYSP";
+    case Instruction::ADJUST_PROC_VOLTAGES:
+      return "ADJUST_PROC_VOLTAGES";
   }
   return "";
 }

--- a/dllNetwork/server/Instruction.H
+++ b/dllNetwork/server/Instruction.H
@@ -210,6 +210,11 @@ class Instruction{
         PNORPUT,
 
         QUERYSP,
+
+        ADJUST_PROC_VOLTAGES,
+
+        I2CRESETLIGHT,
+        I2CRESETFULL,
     } InstructionCommand;
 
     /** @name Instruction Constructor */

--- a/dllNetwork/server/ServerFSIInstruction.C
+++ b/dllNetwork/server/ServerFSIInstruction.C
@@ -26,6 +26,7 @@
 #include <adal_scan.h>
 #include <adal_mbx.h>
 #include <adal_sbefifo.h>
+#include <adal_iic.h>
 
 //FIXME remove these
 adal_t * system_gp_reg_open(const char * device, int flags, int type)
@@ -727,6 +728,33 @@ ssize_t ServerFSIInstruction::scom_set_register(Handle * i_handle, InstructionSt
 #else
         rc = adal_scom_set_register((adal_t *) i_handle, address, l_data);
 #endif
+        return rc;
+}
+
+ssize_t ServerFSIInstruction::iic_set_register(Handle * i_handle, InstructionStatus & o_status)
+{
+        ssize_t rc = 0;
+        unsigned long l_data = data.getWord(0);
+#ifdef TESTING
+        TEST_PRINT("adal_iic_set_register((adal_t *) i_handle, %08X, %08lX);\n", address, l_data);
+        rc = 4;
+#else
+        rc = adal_iic_set_register((adal_t *) i_handle, address, l_data);
+#endif
+        return rc;
+}
+
+ssize_t ServerFSIInstruction::iic_get_register(Handle * i_handle, ecmdDataBufferBase & o_data, InstructionStatus & o_status)
+{
+        ssize_t rc = 0;
+        unsigned long l_data = 0;
+#ifdef TESTING
+        TEST_PRINT("adal_iic_get_register((adal_t *) i_handle, %08X, &l_data);\n", address);
+        rc = 4;
+#else
+        rc = adal_iic_get_register((adal_t *) i_handle, address, &l_data);
+#endif
+        o_data.setWord(0, l_data);
         return rc;
 }
 

--- a/dllNetwork/server/ServerFSIInstruction.H
+++ b/dllNetwork/server/ServerFSIInstruction.H
@@ -63,6 +63,7 @@ class ServerFSIInstruction : public FSIInstruction
     ssize_t mbx_get_register(Handle * i_handle, ecmdDataBufferBase & o_data, InstructionStatus & o_status);
     ssize_t gp_reg_get(Handle * i_handle, ecmdDataBufferBase & o_data, InstructionStatus & o_status);
     ssize_t sbefifo_get_register(Handle * i_handle, ecmdDataBufferBase & o_data, InstructionStatus & o_status);
+    ssize_t iic_get_register(Handle * i_handle, ecmdDataBufferBase & o_data, InstructionStatus & o_status);
 
     ssize_t scan_set_register(Handle * i_handle, InstructionStatus & o_status);
     ssize_t scom_set_register(Handle * i_handle, InstructionStatus & o_status);
@@ -70,6 +71,7 @@ class ServerFSIInstruction : public FSIInstruction
     ssize_t mbx_set_register(Handle * i_handle, InstructionStatus & o_status);
     ssize_t gp_reg_set(Handle * i_handle, InstructionStatus & o_status);
     ssize_t sbefifo_set_register(Handle * i_handle, InstructionStatus & o_status);
+    ssize_t iic_set_register(Handle * i_handle, InstructionStatus & o_status);
 };
 
 #endif // _ServerFSIInstruction_H

--- a/dllNetwork/server/ServerI2CInstruction.C
+++ b/dllNetwork/server/ServerI2CInstruction.C
@@ -99,19 +99,12 @@ uint32_t system_iic_reset(Handle * i_handle, int i_type)
     if( i_type == ADAL_RESET_FULL || i_type == ADAL_RESET_LIGHT)
     {
         // set diag_mode on
-#ifdef _BIG_ENDIAN
-        rc = adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_MODE, 0x400000000 );
+        rc = adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_MODE, 0x00000004 );
         if ( global_server_debug )
-            printf("adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_MODE, 0x400000000 )  rc(%d) errno(%d)\n", rc, errno);
+            printf("adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_MODE, 0x00000004 )  rc(%d) errno(%d)\n", rc, errno);
         if ( rc < 0 )
             return rc;
-#else
-        rc = adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_MODE, 0x20000000 );
-        if ( global_server_debug )
-            printf("adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_MODE, 0x20000000 )  rc(%d) errno(%d)\n", rc, errno);
-        if ( rc < 0 )
-            return rc;
-#endif
+
         // toggle clock line
         rc = adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_RESET_SCL, 0x0 );
         if ( global_server_debug )

--- a/dllNetwork/server/ServerI2CInstruction.C
+++ b/dllNetwork/server/ServerI2CInstruction.C
@@ -43,6 +43,8 @@
 #include <sys/time.h>
 #endif
 
+extern bool global_server_debug;
+
 /* For this code device string is used to build file paths of valid i2c devices */
 /* this include fsi i2c and native i2c devices */
 /* we'll determine a valid device by what we find in the filesystem */
@@ -78,6 +80,88 @@ void system_iic_close(system_iic * handle)
         close(handle->fd);
         delete handle;
     }
+}
+
+uint32_t system_iic_reset(Handle * i_handle, int i_type)
+{
+    int rc = 0;
+
+    if( i_type == ADAL_RESET_LIGHT || i_type == ADAL_RESET_FULL )
+    {
+        rc = adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_RESET, 0x0 );
+        if ( global_server_debug )
+            printf("adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_RESET, 0x0 )  rc(%d) errno(%d)\n", rc, errno);
+        if ( rc < 0 )
+            return rc;
+    }
+
+    // always attempt full reset even for light mode
+    if( i_type == ADAL_RESET_FULL || i_type == ADAL_RESET_LIGHT)
+    {
+        // set diag_mode on
+#ifdef _BIG_ENDIAN
+        rc = adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_MODE, 0x400000000 );
+        if ( global_server_debug )
+            printf("adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_MODE, 0x400000000 )  rc(%d) errno(%d)\n", rc, errno);
+        if ( rc < 0 )
+            return rc;
+#else
+        rc = adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_MODE, 0x20000000 );
+        if ( global_server_debug )
+            printf("adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_MODE, 0x20000000 )  rc(%d) errno(%d)\n", rc, errno);
+        if ( rc < 0 )
+            return rc;
+#endif
+        // toggle clock line
+        rc = adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_RESET_SCL, 0x0 );
+        if ( global_server_debug )
+            printf("adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_RESET_SCL, 0x0 )  rc(%d) errno(%d)\n", rc, errno);
+        if ( rc < 0 )
+            return rc;
+
+        rc = adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_SET_SCL, 0x0 );
+        if ( global_server_debug )
+            printf("adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_SET_SCL, 0x0 )  rc(%d) errno(%d)\n", rc, errno);
+        if ( rc < 0 )
+            return rc;
+
+        // stop signal
+        rc = adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_RESET_SCL, 0x0 );
+        if ( global_server_debug )
+            printf("adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_RESET_SCL, 0x0 )  rc(%d) errno(%d)\n", rc, errno);
+        if ( rc < 0 )
+            return rc;
+
+        rc = adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_RESET_SDA, 0x0 );
+        if ( global_server_debug )
+            printf("adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_RESET_SDA, 0x0 )  rc(%d) errno(%d)\n", rc, errno);
+        if ( rc < 0 )
+            return rc;
+
+        rc = adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_SET_SCL, 0x0 );
+        if ( global_server_debug )
+            printf("adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_SET_SCL, 0x0 )  rc(%d) errno(%d)\n", rc, errno);
+        if ( rc < 0 )
+            return rc;
+
+        rc = adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_SET_SDA, 0x0 );
+        if ( global_server_debug )
+            printf("adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_SET_SDA, 0x0 )  rc(%d) errno(%d)\n", rc, errno);
+        if ( rc < 0 )
+            return rc;
+
+        // set diag mode off
+        rc = adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_MODE, 0x0 );
+        if ( global_server_debug )
+            printf("adal_iic_set_register( (adal_t *) i_handle, ADAL_IIC_REG_MODE, 0x0 )  rc(%d) errno(%d)\n", rc, errno);
+        if ( rc < 0 )
+            return rc;
+    }
+    else
+    {
+        return -1;
+    } 
+    return rc;
 }
 
 uint32_t ServerI2CInstruction::iic_open(Handle ** handle, InstructionStatus & o_status)
@@ -179,6 +263,13 @@ uint32_t ServerI2CInstruction::iic_open(Handle ** handle, InstructionStatus & o_
             system_iic_close(l_handle);
             *handle = NULL;
             return SERVER_I2C_OPEN_FAIL;
+        }
+        else
+        {
+            if (flags & INSTRUCTION_FLAG_SERVER_DEBUG) {
+                snprintf(errstr, 200, "SERVER_DEBUG : I2C_FUNCS = %08X\n", l_handle->funcs);
+                o_status.errorMessage.append(errstr);
+            }
         }
     }
 
@@ -597,6 +688,66 @@ ssize_t ServerI2CInstruction::iic_write(Handle * i_handle, InstructionStatus & o
         }
         delete [] rdwr_data->msgs;
         delete rdwr_data;
+
+        return rc;
+    } 
+}
+
+uint32_t ServerI2CInstruction::iic_reset(Handle * i_handle, int i_type)
+{
+#ifdef SERVER_PRINT_PERF
+    struct timeval start_time;
+    struct timeval end_time;
+#endif
+
+    uint32_t rc = 0;
+
+    if ( iv_deviceIdx == iv_adalFsiDevice )
+    {
+        int timeout = 60 * 1000;
+#ifdef TESTING
+        TESTPRINT("rc = adal_iic_config((adal_t *) i_handle, ADAL_CONFIG_WRITE, ADAL_IIC_CFG_TIMEOUT, %x, 0);\n", timeout);
+#else
+        ssize_t rc = adal_iic_config((adal_t *) i_handle, ADAL_CONFIG_WRITE, ADAL_IIC_CFG_TIMEOUT, &timeout, 0);
+        if (rc)
+        {
+            return rc;
+        }
+#endif
+
+#ifdef SERVER_PRINT_PERF
+        gettimeofday(&start_time, NULL);
+#endif
+#ifdef TESTING
+        TESTPRINT("len = adal_iic_reset((adal_t *) i_handle, i_type));\n");
+#else
+        rc = adal_iic_reset((adal_t *) i_handle, i_type);
+#endif
+#ifdef SERVER_PRINT_PERF
+        gettimeofday(&end_time, NULL);
+        int perf_run_time = (end_time.tv_sec - start_time.tv_sec) * 1000 + ((end_time.tv_usec - start_time.tv_usec) / 1000);
+        printf("time: %d, rc %d\n", perf_run_time, len);
+#endif
+        return rc;
+    }
+    else
+    {
+
+#ifdef TESTING
+        TESTPRINT("rc = system_iic_reset((adal_t *) handle, i_type);\n");
+#else
+        // disabling calling system_iic_reset 
+        //rc = system_iic_reset( i_handle, i_type );
+#endif
+
+        if (rc < 0 && i_type == ADAL_RESET_FULL)
+        {
+            rc = SERVER_I2C_RESET_FULL_FAIL;
+        }
+        else if (rc < 0 && i_type == ADAL_RESET_LIGHT)
+        {
+            rc = SERVER_I2C_RESET_LIGHT_FAIL;
+        }
 
         return rc;
     } 

--- a/dllNetwork/server/ServerI2CInstruction.H
+++ b/dllNetwork/server/ServerI2CInstruction.H
@@ -43,6 +43,7 @@ class ServerI2CInstruction : public I2CInstruction
     uint32_t iic_config_device_offset(Handle * i_handle, InstructionStatus & o_status);
     ssize_t iic_read(Handle * i_handle, ecmdDataBufferBase & o_data, InstructionStatus & o_status);
     ssize_t iic_write(Handle * i_handle, InstructionStatus & o_status);
+    uint32_t iic_reset(Handle * i_handle, int i_type);
 
     private:
     uint32_t iv_deviceIdx;

--- a/dllNetwork/server/adals/iic_master/adal_iic_interfaces.h
+++ b/dllNetwork/server/adals/iic_master/adal_iic_interfaces.h
@@ -601,6 +601,30 @@ int adal_siic_write(adal_t* adal, uint8_t dev_addr, uint8_t offset, uint8_t* dat
  */
 int adal_siic_reset_irq(adal_t* adal, uint8_t dev_addr, uint8_t offset, uint8_t* flags, uint8_t len);
 
+/*!
+ * @brief	Read a single register in IIC Engine.
+ *		This is for debug only.
+ *
+ * @param	adal		adal_t of the target device.
+ * @param	registerNo	Address of the register.
+ * @param	data		Data read out of the register.
+ *
+ * @return	'0' on success, negative on error.
+ */
+ssize_t adal_iic_get_register(adal_t * adal, int registerNo, unsigned long * data);
+
+/*!
+ * @brief	Write a single register in IIC Engine.
+ *		This is for debug only.
+ *
+ * @param	adal		adal_t of the target device.
+ * @param	registerNo	Address of the register.
+ * @param	data		Data written to the register.
+ *
+ * @return	'0' on success, negative on error..
+ */
+ssize_t adal_iic_set_register(adal_t * adal, int registerNo, unsigned long data);
+
 
 #ifdef __cplusplus
 }

--- a/dllNetwork/server/adals/iic_master/adal_iic_types.h
+++ b/dllNetwork/server/adals/iic_master/adal_iic_types.h
@@ -86,6 +86,25 @@ enum
 	ADAL_IIC_FLAG_SPECIAL_RD = IIC_SPECIAL_RD,
 };
 
+enum IIC_REGS
+{
+    ADAL_IIC_REG_FIFO        = 0,
+    ADAL_IIC_REG_COMMAND     = 1,
+    ADAL_IIC_REG_MODE        = 2,
+    ADAL_IIC_REG_WATERMARK   = 3,
+    ADAL_IIC_REG_INTMASK     = 4,
+    ADAL_IIC_REG_INTERRUPT   = 6,
+    ADAL_IIC_REG_STATUS      = 7,
+    ADAL_IIC_REG_RESET       = 7,
+    ADAL_IIC_REG_RESET_ERRORS= 8,
+    ADAL_IIC_REG_SET_SCL     = 9,
+    ADAL_IIC_REG_BUSY        = 10,
+    ADAL_IIC_REG_RESET_SCL   = 11,
+    ADAL_IIC_REG_SET_SDA     = 12,
+    ADAL_IIC_REG_RESET_SDA   = 13,
+    ADAL_IIC_REG_FIFO4       = 14,
+};
+
 typedef iic_opts_t adal_iic_opts_t;
 typedef iic_xfr_opts_t adal_iic_xfr_opts_t;
 typedef iic_rec_pol_t adal_iic_rec_pol_t;


### PR DESCRIPTION
Resolves issue where server would segfault if an i2creset request was sent from the client.

Signed-off-by: Steven B. Janssen <janssens@us.ibm.com>