### PR TITLE
I2ctimeout fixes/enhancements for croserver 

### DIFF
--- a/dllNetwork/server/I2CInstruction.C
+++ b/dllNetwork/server/I2CInstruction.C
@@ -63,7 +63,7 @@ address(0)
     i_data->shareBuffer(&data);
   }
   /* use version one protocol if i2cFlags is zero */
-  if (version == 0x2 && i2cFlags == 0x0) {
+  if (version == 0x2 && ((i2cFlags & INSTRUCTION_I2C_FLAG_MASK) == 0x0)) {
     version = 0x1;
   }
 }
@@ -90,7 +90,7 @@ uint32_t I2CInstruction::setup(InstructionCommand i_command, uint32_t i_cfamid, 
   }
   version = 0x2;
   /* use version one protocol if i2cFlags is zero */
-  if (version == 0x2 && i2cFlags == 0x0) {
+  if (version == 0x2 && ((i2cFlags & INSTRUCTION_I2C_FLAG_MASK) == 0x0)) {
     version = 0x1;
   }
   return 0;

--- a/dllNetwork/server/InstructionFlag.C
+++ b/dllNetwork/server/InstructionFlag.C
@@ -134,6 +134,10 @@ std::string InstructionI2CFlagToString(uint32_t i_i2cFlag) {
   std::string returnString = "";
   if (INSTRUCTION_I2C_FLAG_NACK_RETRY_100MS & i_i2cFlag)
     returnString += "INSTRUCTION_I2C_FLAG_NACK_RETRY_100MS, ";
+  if (INSTRUCTION_I2C_FLAG_RETRY_MASK & i_i2cFlag)
+    returnString += "INSTRUCTION_I2C_FLAG_RETRY_MASK, ";
+  if (INSTRUCTION_I2C_FLAG_MSG_SIZE_MASK & i_i2cFlag)
+    returnString += "INSTRUCTION_I2C_FLAG_MSG_SIZE_MASK, ";
   return returnString;
 }
 

--- a/dllNetwork/server/InstructionFlag.H
+++ b/dllNetwork/server/InstructionFlag.H
@@ -107,6 +107,11 @@ std::string InstructionTapToString(uint32_t i_tap);
 /*  These are the Instruction Flag Defines                            */
 /* ------------------------------------------------------------------ */
 #define INSTRUCTION_I2C_FLAG_NACK_RETRY_100MS   0x80000000
+#define INSTRUCTION_I2C_FLAG_MASK               0xFF000000
+#define INSTRUCTION_I2C_FLAG_RETRY_MASK         0x00FFA000  // specifies number of bytes written per jiffy, a jiffy is 10ms            
+#define INSTRUCTION_I2C_FLAG_RETRY_SHIFT        14
+#define INSTRUCTION_I2C_FLAG_MSG_SIZE_MASK      0x00003FFF  // max value of 8192 accepted
+#define INSTRUCITON_I2C_FLAG_MSG_SIZE_SHIFT     0
 
 /**
  @brief function to create string from instruction I2C flag


### PR DESCRIPTION
overloading i2cFlags to incorporate a max message size request along with number of retries.
Enhance i2c read to use a single ioctl and queue up the messages.
Setup and use the I2C_TIMEOUT functionality for the driver.