### PR TITLE
Moved doxygen default gen dir to standard out location

### DIFF
--- a/config.py
+++ b/config.py
@@ -827,11 +827,11 @@ else:
     INSTALL_BIN_PATH = os.path.join(INSTALL_PATH, "bin")
 buildvars["INSTALL_BIN_PATH"] = INSTALL_BIN_PATH
 
-# If DOXYGEN_PATH wasn't given, use INSTALL_PATH
+# If DOXYGEN_PATH wasn't given, use OUTPATH
 if ("DOXYGEN_PATH" in os.environ):
     DOXYGEN_PATH = os.environ["DOXYGEN_PATH"]
 else:
-    DOXYGEN_PATH = os.path.join(INSTALL_PATH, "doxygen")
+    DOXYGEN_PATH = os.path.join(OUTPATH, "doxygen")
 
 # Setup our capi/perl/python paths based on DOXYGEN_PATH
 DOXYGEN_CAPI_PATH = os.path.join(DOXYGEN_PATH, "Capi")

--- a/ecmd-core/pyecmd/makefile
+++ b/ecmd-core/pyecmd/makefile
@@ -20,7 +20,7 @@ all:
 	${run-all}
 
 doxygen:
-	${VERBOSE}${MAKE} -C ../.. doxygen ${MAKEFLAGS} --no-print-directory
+	${VERBOSE}${MAKE} -C ../.. doxygen-create ${MAKEFLAGS} --no-print-directory
 
 generate: doxygen ${GENERATED_PY} ${CONSTANTS_PY}
 

--- a/makefile
+++ b/makefile
@@ -65,7 +65,10 @@ build: ${BUILD_TARGETS}
 
 test: ${BUILD_TARGETS}
 
-doxygen: dir
+doxygen: doxygen-create
+	${VERBOSE}cp -r ${DOXYGEN_PATH} ${INSTALL_PATH}
+
+doxygen-create: dir
 	@mkdir -p ${DOXYGEN_CAPI_PATH}
 	${VERBOSE}${MAKE} doxygen-capi ${MAKEFLAGS} --no-print-directory
 	@mkdir -p ${DOXYGEN_PERLAPI_PATH}


### PR DESCRIPTION
Pyecmd changes were causing an untracked install dir to always
be generated.  If part of the default build, it needs to go to a
standard excluded location.

No part of the install rules were calling doxygen, but this could
break people counting on the current behavior.