### PR TITLE
Fix Python wrapper for ecmdDataBuffer::readFile() and ecmdDataBuffer:…

### DIFF
--- a/ecmd-core/capi/ecmdDataBuffer.H
+++ b/ecmd-core/capi/ecmdDataBuffer.H
@@ -1543,7 +1543,11 @@ public:
    * @retval ECMD_DBUF_FOPEN_FAIL Unable to open the file for read
    * @retval ECMD_DBUF_XSTATE_ERROR If XState format is requested when XState is not defined for the configuration
    */
+#ifdef ECMD_PYAPI
+  uint32_t readFile(const char * i_filename, ecmdFormatType_t i_format, std::string *o_property); /* Reads in the buffer (in the specified format) into the databuffer */
+#else
   uint32_t readFile(const char * i_filename, ecmdFormatType_t i_format, std::string *o_property = NULL); /* Reads in the buffer (in the specified format) into the databuffer */
+#endif
 
   /**
    * @brief Read data from the file into the buffer  
@@ -1558,7 +1562,12 @@ public:
    * @retval ECMD_DBUF_DATANUMBER_NOT_FOUND If requested i_dataNumber is not available in file
    * ECMD_SAVE_FORMAT_BINARY_DATA not accepted when i_dataNumber != 0
    */
+#ifdef ECMD_PYAPI
+  uint32_t readFileMultiple(const char * i_filename, ecmdFormatType_t i_format, uint32_t i_dataNumber, std::string *o_property);
+  uint32_t readFileMultiple(const char * i_filename, ecmdFormatType_t i_format) { return readFileMultiple(i_filename, i_format, 0, NULL); }
+#else
   uint32_t readFileMultiple(const char * i_filename, ecmdFormatType_t i_format, uint32_t i_dataNumber=0, std::string *o_property = NULL); /* Reads out the buffer (in the  specified format) from the file */
+#endif
 
   /**
    * @brief Read data from the file into the buffer

--- a/ecmd-core/pyapi/ecmdCommon.i
+++ b/ecmd-core/pyapi/ecmdCommon.i
@@ -47,3 +47,26 @@
   // All done copying our data from the C array into python, free the malloc from in typemap
   free($1);
 }
+
+// typemaps to support ecmdDataBuffer::readFile() and readFileMultiple use of std::string *
+// value from std::string * argument will be returned as part of the tuple
+%typemap(in, numinputs=0) std::string * o_property (std::string temp) { $1 = &temp; }
+%typemap(argout) std::string * o_property {
+  PyObject *o, *o2, *o3;
+  o = PyString_FromString($1->c_str());
+  if ((!$result) || ($result == Py_None)) {
+    $result = o;
+  } else {
+    if (!PyTuple_Check($result)) {
+      PyObject *o2 = $result;
+      $result = PyTuple_New(1);
+      PyTuple_SetItem($result, 0, o2);
+    }
+    o3 = PyTuple_New(1);
+    PyTuple_SetItem(o3, 0, o);
+    o2 = $result;
+    $result = PySequence_Concat(o2, o3);
+    Py_DECREF(o2);
+    Py_DECREF(o3);
+  }
+}


### PR DESCRIPTION
…:readFileMultiple()

  * create typemap to handle std::string * argument
  * remove default arguement signatures of the methods
Signed-off-by: Matt K. Light <mklight@us.ibm.com>