### PR TITLE
return uint32_t * value for extract() and extractFromRight() as part o…

### DIFF
--- a/ecmd-core/capi/ecmdDataBuffer.H
+++ b/ecmd-core/capi/ecmdDataBuffer.H
@@ -551,7 +551,7 @@ public:
    */
   uint32_t reverse();
 
-#ifndef ECMD_PERLAPI
+#if !defined(ECMD_PERLAPI) && !defined(ECMD_PYAPI)
   /**
    * @brief Apply an inversion mask to data inside buffer
    * @param i_invMask Buffer that stores inversion mask
@@ -559,7 +559,7 @@ public:
    * @retval ECMD_DBUF_SUCCESS on success
    */
   uint32_t applyInversionMask(const uint32_t * i_invMask, uint32_t i_invByteLen);
-#endif //ECMD_PERLAPI
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   /**
    * @brief Apply an inversion mask to data inside buffer
@@ -583,7 +583,7 @@ public:
    */
   uint32_t insert(const ecmdDataBuffer & i_bufferIn, uint32_t i_targetStart, uint32_t i_len, uint32_t i_sourceStart = 0);
 
-#ifndef ECMD_PERLAPI
+#if !defined(ECMD_PERLAPI) && !defined(ECMD_PYAPI)
   /**
    * @brief Copy part of a uint32_t array into this DataBuffer
    * @param i_data uint32_t array to copy into this DataBuffer - data is taken left aligned
@@ -596,7 +596,7 @@ public:
    * @retval ECMD_DBUF_BUFFER_OVERFLOW operation requested out of range
    */
   uint32_t insert(const uint32_t * i_data, uint32_t i_targetStart, uint32_t i_len, uint32_t i_sourceStart = 0);
-#endif //ECMD_PERLAPI
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   /**
    * @brief Copy part of a uint32_t into the DataBuffer
@@ -611,7 +611,7 @@ public:
    */
   uint32_t insert(uint32_t i_data, uint32_t i_targetStart, uint32_t i_len, uint32_t i_sourceStart = 0);
 
-#ifndef ECMD_PERLAPI
+#if !defined(ECMD_PERLAPI) && !defined(ECMD_PYAPI)
   /**
    * @brief Copy a right aligned (decimal) uint32_t array into this DataBuffer
    * @param i_data uint32_t array to copy into this DataBuffer - data is taken right aligned
@@ -625,7 +625,7 @@ public:
    * NOTE : Data is assumed to be aligned on the word boundary of i_len
    */
   uint32_t insertFromRight(const uint32_t * i_data, uint32_t i_start, uint32_t i_len);
-#endif //ECMD_PERLAPI
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   /**
    * @brief Copy a right aligned (decimal) uint32_t into the DataBuffer
@@ -639,7 +639,7 @@ public:
    */
   uint32_t insertFromRight(uint32_t i_data, uint32_t i_start, uint32_t i_len);
 
-#ifndef ECMD_PERLAPI
+#if !defined(ECMD_PERLAPI) && !defined(ECMD_PYAPI)
   /**
    * @brief Copy part of a uint16_t array into this DataBuffer
    * @param i_datain uint16_t array to copy into this DataBuffer - data is taken left aligned
@@ -745,7 +745,7 @@ public:
    * NOTE : Data is assumed to be aligned on the word boundary of i_len
    */
   uint32_t insertFromRight(const uint8_t i_datain, uint32_t i_start, uint32_t i_len);
-#endif //ECMD_PERLAPI
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   /**
    * @brief Copy data from this DataBuffer into another
@@ -772,6 +772,7 @@ public:
    */
   uint32_t extract(uint32_t * o_data, uint32_t i_start, uint32_t i_len) const;
 
+#ifndef ECMD_PYAPI
   /**
    * @brief Copy data from this DataBuffer into a uint16_t buffer
    * @param o_data uint16_t buffer to copy into - data is placed left aligned - must be pre-allocated
@@ -793,7 +794,8 @@ public:
    * @retval ECMD_DBUF_BUFFER_OVERFLOW operation requested out of range
    */
   uint32_t extract(uint8_t * o_data, uint32_t i_start, uint32_t i_len) const;
-#endif //ECMD_PERLAPI
+#endif // ECMD_PYAPI
+#endif // ECMD_PERLAPI
 
   /**
    * @brief Copy data from this buffer into another at a given offset, preserving the size and other data in the output buffer
@@ -807,7 +809,7 @@ public:
    */
   uint32_t extractPreserve(ecmdDataBuffer & o_bufferOut, uint32_t i_start, uint32_t i_len, uint32_t i_targetStart = 0) const;
 
-#ifndef ECMD_PERLAPI
+#if !defined(ECMD_PERLAPI) && !defined(ECMD_PYAPI)
   /**
    * @brief Copy data from this DataBuffer into a generic output buffer at a given offset, preserving the size and other data in the output buffer
    * @param o_data Array of data to write into, must be pre-allocated
@@ -846,7 +848,7 @@ public:
    * @retval ECMD_DBUF BUFFER_OVERFLOW request is out of range for this DataBuffer, output buffer is NOT checked for overflow
    */
   uint32_t extractPreserve(uint8_t * o_data, uint32_t i_start, uint32_t i_len, uint32_t i_targetStart = 0) const;
-#endif //ECMD_PERLAPI
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   /**
    * @brief Copy data from this DataBuffer into another DataBuffer and right justify
@@ -871,6 +873,7 @@ public:
    */
   uint32_t extractToRight(uint32_t * o_data, uint32_t i_start, uint32_t i_len) const;
 
+#ifndef ECMD_PYAPI
   /**
    * @brief Copy data from this DataBuffer into a uint16_t buffer
    * @param o_data uint16_t buffer to copy into - data is placed right aligned - must be pre-allocated
@@ -892,7 +895,8 @@ public:
    * @retval ECMD_DBUF_BUFFER_OVERFLOW operation requested out of range
    */
   uint32_t extractToRight(uint8_t * o_data, uint32_t i_start, uint32_t i_len) const;
-#endif //ECMD_PERLAPI
+#endif // ECMD_PYAPI
+#endif // ECMD_PERLAPI
 
   /**
    * @brief Concatenate 2 DataBuffers into in this one
@@ -937,7 +941,7 @@ public:
    */
   uint32_t setOr(uint32_t i_data, uint32_t i_startbit, uint32_t i_len);
 
-#ifndef ECMD_PERLAPI
+#if !defined(ECMD_PERLAPI) && !defined(ECMD_PYAPI)
   /**
    * @brief OR data into DataBuffer
    * @param i_data uint32_t buffer to OR data from - data is taken left aligned
@@ -948,7 +952,7 @@ public:
    * @retval ECMD_DBUF_BUFFER_OVERFLOW operation requested out of range
    */
   uint32_t setOr(const uint32_t * i_data, uint32_t i_startbit, uint32_t i_len);
-#endif //ECMD_PERLAPI
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   /**
    * @brief OR data into DataBuffer
@@ -971,7 +975,7 @@ public:
    */
   uint32_t setXor(const ecmdDataBuffer & i_bufferIn, uint32_t i_startbit, uint32_t i_len);
 
-#ifndef ECMD_PERLAPI
+#if !defined(ECMD_PERLAPI) && !defined(ECMD_PYAPI)
   /**
    * @brief XOR data into DataBuffer
    * @param i_data uint32_t buffer to XOR data from - data is taken left aligned
@@ -982,7 +986,7 @@ public:
    * @retval ECMD_DBUF_BUFFER_OVERFLOW operation requested out of range
    */
   uint32_t setXor(const uint32_t * i_data, uint32_t i_startbit, uint32_t i_len);
-#endif //ECMD_PERLAPI
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   /**
    * @brief XOR data into DataBuffer
@@ -1018,7 +1022,7 @@ public:
    */
   uint32_t setAnd(uint32_t i_data, uint32_t i_startbit, uint32_t i_len);
 
-#ifndef ECMD_PERLAPI
+#if !defined(ECMD_PERLAPI) && !defined(ECMD_PYAPI)
   /**
    * @brief AND data into DataBuffer
    * @param i_data uint32_t buffer to AND data from - data is taken left aligned
@@ -1029,7 +1033,7 @@ public:
    * @retval ECMD_DBUF_BUFFER_OVERFLOW operation requested out of range
    */
   uint32_t setAnd(const uint32_t * i_data, uint32_t i_startbit, uint32_t i_len);
-#endif //ECMD_PERLAPI
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   /**
    * @brief Copy entire contents of this ecmdDataBuffer into o_copyBuffer 
@@ -1053,9 +1057,7 @@ public:
    * @post this DataBuffer is allocated, is an exact duplicate of the other
    */
   ecmdDataBuffer& operator=(const ecmdDataBufferBase & i_master);
-#endif // ECMD_PERLAPI && ECMD_PYAPI
 
-#ifndef ECMD_PERLAPI
   /* These are only to be used to apply a buffer to the entire ecmdDataBuffer, not just sections */
   /**
    * @brief Copy buffer into this ecmdDataBuffer
@@ -1119,7 +1121,6 @@ public:
    * @retval ECMD_DBUF_BUFFER_OVERFLOW operation requested out of range
    */
   uint32_t memCopyOut(uint8_t * o_buf, uint32_t i_bytes) const; /* Does a memcpy from ecmdDataBufferBase into supplied buffer */
-#endif //ECMD_PERLAPI
 
   /**
    * @brief Flatten all the object data into a uint8_t buffer
@@ -1162,6 +1163,7 @@ public:
    * @retval Number of bytes needed
    */
   uint32_t flattenSize(void) const;
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   //@}
 

--- a/ecmd-core/capi/ecmdDataBufferBase.H
+++ b/ecmd-core/capi/ecmdDataBufferBase.H
@@ -598,7 +598,7 @@ public:
    */
   uint32_t reverse();
 
-#ifndef ECMD_PERLAPI
+#if !defined(ECMD_PERLAPI) && !defined(ECMD_PYAPI)
   /**
    * @brief Apply an inversion mask to data inside buffer
    * @param i_invMask Buffer that stores inversion mask
@@ -606,7 +606,7 @@ public:
    * @retval ECMD_DBUF_SUCCESS on success
    */
   uint32_t applyInversionMask(const uint32_t * i_invMask, uint32_t i_invByteLen);
-#endif //ECMD_PERLAPI
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   /**
    * @brief Apply an inversion mask to data inside buffer
@@ -630,7 +630,7 @@ public:
    */
   virtual uint32_t insert(const ecmdDataBufferBase & i_bufferIn, uint32_t i_targetStart, uint32_t i_len, uint32_t i_sourceStart = 0);
 
-#ifndef ECMD_PERLAPI
+#if !defined(ECMD_PERLAPI) && !defined(ECMD_PYAPI)
   /**
    * @brief Copy part of a uint32_t array into this DataBuffer
    * @param i_data uint32_t array to copy into this DataBuffer - data is taken left aligned
@@ -643,7 +643,7 @@ public:
    * @retval ECMD_DBUF_BUFFER_OVERFLOW operation requested out of range
    */
   virtual uint32_t insert(const uint32_t * i_data, uint32_t i_targetStart, uint32_t i_len, uint32_t i_sourceStart = 0);
-#endif //ECMD_PERLAPI
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   /**
    * @brief Copy part of a uint32_t into the DataBuffer
@@ -658,7 +658,7 @@ public:
    */
   uint32_t insert(uint32_t i_data, uint32_t i_targetStart, uint32_t i_len, uint32_t i_sourceStart = 0);
 
-#ifndef ECMD_PERLAPI
+#if !defined(ECMD_PERLAPI) && !defined(ECMD_PYAPI)
   /**
    * @brief Copy a right aligned (decimal) uint32_t array into this DataBuffer
    * @param i_data uint32_t array to copy into this DataBuffer - data is taken right aligned
@@ -672,7 +672,7 @@ public:
    * NOTE : Data is assumed to be aligned on the word boundary of i_len
    */
   uint32_t insertFromRight(const uint32_t * i_data, uint32_t i_start, uint32_t i_len);
-#endif //ECMD_PERLAPI
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   /**
    * @brief Copy a right aligned (decimal) uint32_t into the DataBuffer
@@ -692,7 +692,7 @@ public:
   //my $val=736;
   //$data4->insertFromRight($val,0,28);
   // Removing these interfaces keeps the behvavior consistent with previous versions of the perl module - JTA 07/10/09
-#ifndef ECMD_PERLAPI
+#if !defined(ECMD_PERLAPI) && !defined(ECMD_PYAPI)
   /**
    * @brief Copy part of a uint16_t array into this DataBuffer
    * @param i_datain uint16_t array to copy into this DataBuffer - data is taken left aligned
@@ -798,7 +798,7 @@ public:
    * NOTE : Data is assumed to be aligned on the word boundary of i_len
    */
   uint32_t insertFromRight(const uint8_t i_datain, uint32_t i_start, uint32_t i_len);
-#endif // ECMD_PERLAPI
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   /**
    * @brief Copy data from this DataBuffer into another
@@ -825,6 +825,7 @@ public:
    */
   uint32_t extract(uint32_t * o_data, uint32_t i_start, uint32_t i_len) const;
 
+#ifndef ECMD_PYAPI
   /**
    * @brief Copy data from this DataBuffer into a uint16_t buffer
    * @param o_data uint16_t buffer to copy into - data is placed left aligned - must be pre-allocated
@@ -846,7 +847,8 @@ public:
    * @retval ECMD_DBUF_BUFFER_OVERFLOW operation requested out of range
    */
   uint32_t extract(uint8_t * o_data, uint32_t i_start, uint32_t i_len) const;
-#endif //ECMD_PERLAPI
+#endif // ECMD_PYAPI
+#endif // ECMD_PERLAPI
 
   /**
    * @brief Copy data from this buffer into another at a given offset, preserving the size and other data in the output buffer
@@ -860,7 +862,7 @@ public:
    */
   uint32_t extractPreserve(ecmdDataBufferBase & o_bufferOut, uint32_t i_start, uint32_t i_len, uint32_t i_targetStart = 0) const;
 
-#ifndef ECMD_PERLAPI
+#if !defined(ECMD_PERLAPI) && !defined(ECMD_PYAPI)
   /**
    * @brief Copy data from this DataBuffer into a generic output buffer at a given offset, preserving the size and other data in the output buffer
    * @param o_data Array of data to write into, must be pre-allocated
@@ -899,7 +901,7 @@ public:
    * @retval ECMD_DBUF BUFFER_OVERFLOW request is out of range for this DataBuffer, output buffer is NOT checked for overflow
    */
   uint32_t extractPreserve(uint8_t * o_data, uint32_t i_start, uint32_t i_len, uint32_t i_targetStart = 0) const;
-#endif //ECMD_PERLAPI
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   /**
    * @brief Copy data from this DataBuffer into another DataBuffer and right justify
@@ -912,7 +914,7 @@ public:
    */
   uint32_t extractToRight(ecmdDataBufferBase & o_bufferOut, uint32_t i_start, uint32_t i_len) const;
 
- #ifndef ECMD_PERLAPI
+#ifndef ECMD_PERLAPI
  /**
    * @brief Copy data from this DataBuffer into a uint32_t buffer
    * @param o_data uint32_t buffer to copy into - data is placed right aligned - must be pre-allocated
@@ -924,6 +926,7 @@ public:
    */
   uint32_t extractToRight(uint32_t * o_data, uint32_t i_start, uint32_t i_len) const;
 
+#ifndef ECMD_PYAPI
   /**
    * @brief Copy data from this DataBuffer into a uint16_t buffer
    * @param o_data uint16_t buffer to copy into - data is placed right aligned - must be pre-allocated
@@ -945,7 +948,8 @@ public:
    * @retval ECMD_DBUF_BUFFER_OVERFLOW operation requested out of range
    */
   uint32_t extractToRight(uint8_t * o_data, uint32_t i_start, uint32_t i_len) const;
-#endif //ECMD_PERLAPI
+#endif // ECMD_PYAPI
+#endif // ECMD_PERLAPI
 
   /**
    * @brief Concatenate 2 DataBuffers into in this one
@@ -978,7 +982,7 @@ public:
    */
   virtual uint32_t setOr(const ecmdDataBufferBase & i_bufferIn, uint32_t i_startbit, uint32_t i_len);
 
-#ifndef ECMD_PERLAPI
+#if !defined(ECMD_PERLAPI) && !defined(ECMD_PYAPI)
   /**
    * @brief OR data into DataBuffer
    * @param i_data uint32_t buffer to OR data from - data is taken left aligned
@@ -989,7 +993,7 @@ public:
    * @retval ECMD_DBUF_BUFFER_OVERFLOW operation requested out of range
    */
   uint32_t setOr(const uint32_t * i_data, uint32_t i_startbit, uint32_t i_len);
-#endif //ECMD_PERLAPI
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   /**
    * @brief OR data into DataBuffer
@@ -1023,7 +1027,7 @@ public:
    */
   uint32_t setXor(const ecmdDataBufferBase & i_bufferIn, uint32_t i_startbit, uint32_t i_len);
 
-#ifndef ECMD_PERLAPI
+#if !defined(ECMD_PERLAPI) && !defined(ECMD_PYAPI)
   /**
    * @brief XOR data into DataBuffer
    * @param i_data uint32_t buffer to XOR data from - data is taken left aligned
@@ -1034,7 +1038,7 @@ public:
    * @retval ECMD_DBUF_BUFFER_OVERFLOW operation requested out of range
    */
   uint32_t setXor(const uint32_t * i_data, uint32_t i_startbit, uint32_t i_len);
-#endif //ECMD_PERLAPI
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   /**
    * @brief XOR data into DataBuffer
@@ -1059,7 +1063,7 @@ public:
    */
   uint32_t setAnd(const ecmdDataBufferBase & i_bufferIn, uint32_t i_startbit, uint32_t i_len);
 
-#ifndef ECMD_PERLAPI
+#if !defined(ECMD_PERLAPI) && !defined(ECMD_PYAPI)
   /**
    * @brief AND data into DataBuffer
    * @param i_data uint32_t buffer to AND data from - data is taken left aligned
@@ -1070,7 +1074,7 @@ public:
    * @retval ECMD_DBUF_BUFFER_OVERFLOW operation requested out of range
    */
   uint32_t setAnd(const uint32_t * i_data, uint32_t i_startbit, uint32_t i_len);
-#endif //ECMD_PERLAPI
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   /**
    * @brief AND data into DataBuffer
@@ -1098,9 +1102,7 @@ public:
    * @post this DataBuffer is allocated, is an exact duplicate of the other
    */
   ecmdDataBufferBase& operator=(const ecmdDataBufferBase & i_master);
-#endif // ECMD_PERLAPI && ECMD_PYAPI
 
-#ifndef ECMD_PERLAPI
   /* These are only to be used to apply a buffer to the entire ecmdDataBufferBase, not just sections */
   /**
    * @brief Copy buffer into this ecmdDataBufferBase
@@ -1164,7 +1166,6 @@ public:
    * @retval ECMD_DBUF_BUFFER_OVERFLOW operation requested out of range
    */
   uint32_t memCopyOut(uint8_t * o_buf, uint32_t i_bytes) const; /* Does a memcpy from ecmdDataBufferBase into supplied buffer */
-#endif //ECMD_PERLAPI
 
   /**
    * @brief Flatten all the object data into a uint8_t buffer
@@ -1225,6 +1226,7 @@ public:
    * @retval Number of bytes needed
    */
   uint32_t flattenSizeMinCap(void) const;
+#endif // ECMD_PERLAPI && ECMD_PYAPI
 
   //@}
 

--- a/ecmd-core/pyapi/ecmdCommon.i
+++ b/ecmd-core/pyapi/ecmdCommon.i
@@ -48,12 +48,35 @@
   free($1);
 }
 
-// typemaps to support ecmdDataBuffer::readFile() and readFileMultiple use of std::string *
+// typemaps to support ecmdDataBuffer::readFile() and readFileMultiple() use of std::string *
 // value from std::string * argument will be returned as part of the tuple
 %typemap(in, numinputs=0) std::string * o_property (std::string temp) { $1 = &temp; }
 %typemap(argout) std::string * o_property {
   PyObject *o, *o2, *o3;
   o = PyString_FromString($1->c_str());
+  if ((!$result) || ($result == Py_None)) {
+    $result = o;
+  } else {
+    if (!PyTuple_Check($result)) {
+      PyObject *o2 = $result;
+      $result = PyTuple_New(1);
+      PyTuple_SetItem($result, 0, o2);
+    }
+    o3 = PyTuple_New(1);
+    PyTuple_SetItem(o3, 0, o);
+    o2 = $result;
+    $result = PySequence_Concat(o2, o3);
+    Py_DECREF(o2);
+    Py_DECREF(o3);
+  }
+}
+
+// typemaps to support ecmdDataBuffer::extract() and extractToRight() use of uint32_t *
+// value from uint32_t * argument will be returned as part of the tuple
+%typemap(in, numinputs=0) uint32_t * o_data (uint32_t temp) { $1 = &temp; }
+%typemap(argout) uint32_t * o_data {
+  PyObject *o, *o2, *o3;
+  o = PyInt_FromLong(*$1);
   if ((!$result) || ($result == Py_None)) {
     $result = o;
   } else {

--- a/ecmd-core/pyapi/ecmdCommon.i
+++ b/ecmd-core/pyapi/ecmdCommon.i
@@ -73,7 +73,7 @@
 
 // typemaps to support ecmdDataBuffer::extract() and extractToRight() use of uint32_t *
 // value from uint32_t * argument will be returned as part of the tuple
-%typemap(in, numinputs=0) uint32_t * o_data (uint32_t temp) { $1 = &temp; }
+%typemap(in, numinputs=0) uint32_t * o_data (uint32_t temp) { temp = 0; $1 = &temp; }
 %typemap(argout) uint32_t * o_data {
   PyObject *o, *o2, *o3;
   o = PyInt_FromLong(*$1);


### PR DESCRIPTION
…f tuple

remove unused apis that rely on int pointers from the pyapi

Signed-off-by: Matt K. Light <mklight@us.ibm.com>