### PR TITLE
break ecmdParseTokens() out into its own file, for testing purposes

### DIFF
--- a/ecmd-core/capi/ecmdParseTokens.C
+++ b/ecmd-core/capi/ecmdParseTokens.C
@@ -1,0 +1,34 @@
+//IBM_PROLOG_BEGIN_TAG
+/* 
+ * Copyright 2003,2018 IBM International Business Machines Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//IBM_PROLOG_END_TAG
+#include <ecmdSharedUtils.H>
+
+void ecmdParseTokens (std::string line, const char* seperators, std::vector<std::string> & tokens) {
+
+  size_t curStart = 0, curEnd = 0;
+
+  tokens.clear();
+
+  while (1) {
+    curStart = line.find_first_not_of(seperators, curEnd);
+    if (curStart == std::string::npos) break;
+    curEnd = line.find_first_of(seperators,curStart);
+    tokens.push_back(line.substr(curStart, curEnd-curStart));
+  }
+}
+

--- a/ecmd-core/capi/ecmdSharedUtils.C
+++ b/ecmd-core/capi/ecmdSharedUtils.C
@@ -224,20 +224,6 @@ char * ecmdParseOptionWithArgs(int *argc, char **argv[], const char *option) {
   return returnValue;
 }
 
-void ecmdParseTokens (std::string line, const char* seperators, std::vector<std::string> & tokens) {
-
-  size_t curStart = 0, curEnd = 0;
-
-  tokens.clear();
-
-  while (1) {
-    curStart = line.find_first_not_of(seperators, curEnd);
-    if (curStart == std::string::npos) break;
-    curEnd = line.find_first_of(seperators,curStart);
-    tokens.push_back(line.substr(curStart, curEnd-curStart));
-  }
-}
-
 
 std::string ecmdGenEbcdic(ecmdDataBuffer &i_data, int start, int bitLen) {
   std::string ret;

--- a/ecmd-core/capi/makefile
+++ b/ecmd-core/capi/makefile
@@ -13,7 +13,7 @@ INT_INCLUDES  := ecmdDllCapi.H
 
 ### Source
 CAPI_SOURCE := ecmdClientCapi.C ecmdUtils.C ecmdClientCapiFunc.C
-SLIB_SOURCE := ecmdDataBufferBase.C ecmdDataBuffer.C ecmdStructs.C ecmdSharedUtils.C ecmdChipTargetCompare.C
+SLIB_SOURCE := ecmdDataBufferBase.C ecmdDataBuffer.C ecmdStructs.C ecmdSharedUtils.C ecmdParseTokens.C ecmdChipTargetCompare.C
 
 ### Generated source by makedll.pl
 GENERATED_INCLUDES := ecmdDllCapi.H ecmdClientEnums.H


### PR DESCRIPTION
Signed-off-by: Matt K. Light <mklight@us.ibm.com>