### PR TITLE
Removed tests against apis that don't always exist

### DIFF
--- a/ecmd-core/pyecmd/test_api.py
+++ b/ecmd-core/pyecmd/test_api.py
@@ -4,7 +4,9 @@ with Ecmd():
      t = loopTargets("pu", ECMD_SELECTED_TARGETS_LOOP)[0]
      data = t.getScom(0x1234)
      t.putScom(0x1234, 0x10100000)
-     core_id, thread_id = t.targetToSequenceId()
-     unit_id_string = unitIdToString(2)
-     clock_state = t.queryClockState("SOMECLOCK")
+     # These interfaces may not be defined for some plugins
+     # Pull them to prevent compile issues
+     #core_id, thread_id = t.targetToSequenceId()
+     #unit_id_string = unitIdToString(2)
+     #clock_state = t.queryClockState("SOMECLOCK")
      t.relatedTargets("pu.c")


### PR DESCRIPTION
This was breaking against plugins that have the unitid/clock interfaces compiled out

The same argument could be made for scoms, but that hasn't been an issue to date.  Those interfaces are much more common than the ones I commented out.