### PR TITLE
update grep regex for pyecmd makefile locale differences

### DIFF
--- a/ecmd-core/pyecmd/makefile
+++ b/ecmd-core/pyecmd/makefile
@@ -52,7 +52,7 @@ ${CONSTANTS_PY}: ${OUTPY}/ecmd.py
 	@echo "Generating $@ ..."
 	@{ \
 	    echo -n "from ecmd import "; \
-	    grep -E "([A-Z0-9_]+)\s+=\s+_ecmd\.\1" $< | cut -d' ' -f1 | tr '\n' ',' | sed 's/,$$//'; \
+	    grep -E "([[:upper:][:digit:]_]+)\s+=\s+_ecmd\.\1" $< | cut -d' ' -f1 | tr '\n' ',' | sed 's/,$$//'; \
 	 } > $@
 
 # *****************************************************************************


### PR DESCRIPTION
Signed-off-by: Matt K. Light <mklight@us.ibm.com>
Should fix https://github.com/open-power/eCMD/issues/106