### PR TITLE
Added %copyctor to swig for ecmdChipTarget/ecmdLooperData

### DIFF
--- a/ecmd-core/perlapi/ecmdClientPerlapi.i
+++ b/ecmd-core/perlapi/ecmdClientPerlapi.i
@@ -83,6 +83,11 @@
 %template(vectorString)              std::vector<std::string>;
 /*********** End Templates ***********/
 
+/*********** Start Copy Constructors ***********/
+%copyctor ecmdChipTarget;
+%copyctor ecmdLooperData;
+/*********** End Copy Constructors ***********/
+
 /*********** Start Files to swigify ***********/
 %include "ecmdDefines.H"
 %include "ecmdClientPerlapi.H"

--- a/ecmd-core/perlapi/ecmdClientPerlapi.i
+++ b/ecmd-core/perlapi/ecmdClientPerlapi.i
@@ -85,6 +85,37 @@
 
 /*********** Start Copy Constructors ***********/
 %copyctor ecmdChipTarget;
+%copyctor ecmdThreadData;
+%copyctor ecmdChipUnitData;
+%copyctor ecmdChipData;
+%copyctor ecmdSlotData;
+%copyctor ecmdNodeData;
+%copyctor ecmdCageData;
+%copyctor ecmdQueryData;
+%copyctor ecmdRingData;
+%copyctor ecmdArrayData;
+%copyctor ecmdTraceArrayData;
+%copyctor ecmdFastArrayData;
+%copyctor ecmdScomData;
+%copyctor ecmdScomDataHidden;
+%copyctor ecmdLataData;
+%copyctor ecmdScomEntry;
+%copyctor ecmdArrayEntry;
+%copyctor ecmdNameEntry;
+%copyctor ecmdNameVectorEntry;
+%copyctor ecmdIndexVectorEntry;
+%copyctor ecmdIndexEntry;
+%copyctor ecmdLatchEntry;
+%copyctor ecmdLatchQueryData;
+%copyctor ecmdLatchQueryDataHidden;
+%copyctor ecmdProcRegisterInfo;
+%copyctor ecmdCacheData;
+%copyctor ecmdSpyData;
+%copyctor ecmdI2CCmdEntry;
+%copyctor ecmdSimModelInfo;
+%copyctor ecmdConnectionData;
+%copyctor ecmdPnorListEntryData;
+%copyctor ecmdPnorListData;
 %copyctor ecmdLooperData;
 /*********** End Copy Constructors ***********/
 

--- a/ecmd-core/pyapi/ecmdClientPyapi.i
+++ b/ecmd-core/pyapi/ecmdClientPyapi.i
@@ -73,6 +73,11 @@
 %template(uint32_tList)              std::list<uint32_t>;
 /*********** End Templates ***********/
 
+/*********** Start Copy Constructors ***********/
+%copyctor ecmdChipTarget;
+%copyctor ecmdLooperData;
+/*********** End Copy Constructors ***********/
+
 /*********** Start Files to swigify ***********/
 %include "ecmdDefines.H"
 %include "ecmdStructs.H"

--- a/ecmd-core/pyapi/ecmdClientPyapi.i
+++ b/ecmd-core/pyapi/ecmdClientPyapi.i
@@ -75,6 +75,37 @@
 
 /*********** Start Copy Constructors ***********/
 %copyctor ecmdChipTarget;
+%copyctor ecmdThreadData;
+%copyctor ecmdChipUnitData;
+%copyctor ecmdChipData;
+%copyctor ecmdSlotData;
+%copyctor ecmdNodeData;
+%copyctor ecmdCageData;
+%copyctor ecmdQueryData;
+%copyctor ecmdRingData;
+%copyctor ecmdArrayData;
+%copyctor ecmdTraceArrayData;
+%copyctor ecmdFastArrayData;
+%copyctor ecmdScomData;
+%copyctor ecmdScomDataHidden;
+%copyctor ecmdLataData;
+%copyctor ecmdScomEntry;
+%copyctor ecmdArrayEntry;
+%copyctor ecmdNameEntry;
+%copyctor ecmdNameVectorEntry;
+%copyctor ecmdIndexVectorEntry;
+%copyctor ecmdIndexEntry;
+%copyctor ecmdLatchEntry;
+%copyctor ecmdLatchQueryData;
+%copyctor ecmdLatchQueryDataHidden;
+%copyctor ecmdProcRegisterInfo;
+%copyctor ecmdCacheData;
+%copyctor ecmdSpyData;
+%copyctor ecmdI2CCmdEntry;
+%copyctor ecmdSimModelInfo;
+%copyctor ecmdConnectionData;
+%copyctor ecmdPnorListEntryData;
+%copyctor ecmdPnorListData;
 %copyctor ecmdLooperData;
 /*********** End Copy Constructors ***********/
 


### PR DESCRIPTION
- This resolves issues where a real copy constructor is needed
  to create discrete instances of variables

Signed-off-by: Jason Albert <albertj@us.ibm.com>