### PR TITLE
Fix gcc format warning in snprintf

### DIFF
--- a/dllNetwork/server/I2CInstruction.C
+++ b/dllNetwork/server/I2CInstruction.C
@@ -285,7 +285,7 @@ uint32_t I2CInstruction::execute(ecmdDataBuffer & o_data, InstructionStatus & o_
           if (flags & INSTRUCTION_FLAG_SERVER_DEBUG) {
             std::string words;
             genWords(o_data, words);
-            snprintf(errstr, 200, "SERVER_DEBUG : iic_reset() SERVER_I2CRESETLIGHT errno=%d, rc = %zu)\n", errno, rcReset);
+            snprintf(errstr, 200, "SERVER_DEBUG : iic_reset() SERVER_I2CRESETLIGHT errno=%d, rc = %d)\n", errno, rcReset);
             o_status.errorMessage.append(errstr);
           }
          
@@ -322,7 +322,7 @@ uint32_t I2CInstruction::execute(ecmdDataBuffer & o_data, InstructionStatus & o_
           if (flags & INSTRUCTION_FLAG_SERVER_DEBUG) {
             std::string words;
             genWords(o_data, words);
-            snprintf(errstr, 200, "SERVER_DEBUG : iic_reset() SERVER_I2CRESETFULL errno=%d, rc = %zu)\n", errno, rcReset);
+            snprintf(errstr, 200, "SERVER_DEBUG : iic_reset() SERVER_I2CRESETFULL errno=%d, rc = %d)\n", errno, rcReset);
             o_status.errorMessage.append(errstr);
           }
          


### PR DESCRIPTION
gcc 8 produces the following warnings:

server/I2CInstruction.C: In member function ‘virtual uint32_t I2CInstruction::execute(ecmdDataBuffer&, InstructionStatus&, Handle**)’:
server/I2CInstruction.C:288:35: warning: format ‘%zu’ expects argument of type ‘size_t’, but argument 5 has type ‘int’ [-Wformat=]
             snprintf(errstr, 200, "SERVER_DEBUG : iic_reset() SERVER_I2CRESETLIGHT errno=%d, rc = %zu)\n", errno, rcReset);
                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~         ~~~~~~~
server/I2CInstruction.C:325:35: warning: format ‘%zu’ expects argument of type ‘size_t’, but argument 5 has type ‘int’ [-Wformat=]
             snprintf(errstr, 200, "SERVER_DEBUG : iic_reset() SERVER_I2CRESETFULL errno=%d, rc = %zu)\n", errno, rcReset);
                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~         ~~~~~~~

Use the proper format string for the int type of rcReset. Use %d
rather than %i to match the convention used elsewhere in the file.

Signed-off-by: Ryan King <rpking@us.ibm.com>