### PR TITLE
Clarify possibly ambiguous descriptions in i2c help text

### DIFF
--- a/ecmd-core/cmd/help/geti2c.htxt
+++ b/ecmd-core/cmd/help/geti2c.htxt
@@ -20,10 +20,14 @@ Syntax:
         Port            Engine port number to operate on in decimal
 
         SlaveAddress    Slave Device Address in hex
+                        If using a 7-bit address, SlaveAddress is an 8-bit hex
+                        representation with the LSB ignored, so 0 to FF are valid. This
+                        differs from the 7-bit hex representation used in some external
+                        programs, such as those in i2c-tools on Linux.
 
         Bytes           Bytes to read from device
 
-        Offset          Offset into the slave device
+        Offset          Offset into the slave device in decimal
 
         FieldSize       Byte width of the offset
 

--- a/ecmd-core/cmd/help/puti2c.htxt
+++ b/ecmd-core/cmd/help/puti2c.htxt
@@ -24,10 +24,14 @@ Syntax:
         Port            Engine port number to operate on in decimal
 
         SlaveAddress    Slave Device Address in hex
+                        If using a 7-bit address, SlaveAddress is an 8-bit hex
+                        representation with the LSB ignored, so 0 to FF are valid. This
+                        differs from the 7-bit hex representation used in some external
+                        programs, such as those in i2c-tools on Linux.
 
         Data            Data to write to device
 
-        Offset          Offset into the slave device
+        Offset          Offset into the slave device in decimal
 
         FieldSize       Byte width of the offset
 


### PR DESCRIPTION
For a slave address, tools are mixed on whether a slave address, when
given as hex, should be represented by 7 bits or 8 bits, with the
latter including the R/~W bit as the least significant bit. This
means, for example, using a slave address of 0x48 in one tool could
produce equivalent results on the bus as using a slave address of 0x24
in another. In particular, the commonly used Linux i2c-tools package
uses 7 bits, while eCMD uses 8 bits. Being specific in the help text
would be a useful reminder.

Also, it might be natural to think of an offset into an I2C device as
a register address, which is traditionally given in hex. The command
does warn if a non-decimal number is passed in, but this isn't useful
if the attempt at a hex offset only uses decimal digits. Clarify here
that eCMD actually needs it as a decimal.