### PR TITLE
pyapi: Append version specific path to os.path rather than prepend

### DIFF
--- a/ecmd-core/pyapi/init/__init__.py
+++ b/ecmd-core/pyapi/init/__init__.py
@@ -3,9 +3,9 @@ from sys import version_info
 from sys import path as sys_path
 from os import path as os_path
 if version_info[0] >= 3:
-    sys_path.insert(0, os_path.join(os_path.dirname(__file__), "python3"))
+    sys_path.append(os_path.join(os_path.dirname(__file__), "python3"))
     from .python3 import *
 else:
-    sys_path.insert(0, os_path.join(os_path.dirname(__file__), "python2"))
+    sys_path.append(os_path.join(os_path.dirname(__file__), "python2"))
     from .python2 import *
 del sys_path, os_path, version_info

--- a/ecmd-core/pyecmd/base.py
+++ b/ecmd-core/pyecmd/base.py
@@ -99,7 +99,7 @@ def _to_ecmdDataBuffer(buf, defwidth=64):
         ecmd_buf = ecmd.ecmdDataBuffer(len(buf))
         overhang = len(buf) % 64
         bits = buf + bitstring.Bits(64 - (len(buf) % 64)) if overhang else buf # pad to multiples of 64 bits
-        for i in range(len(bits) / 64):
+        for i in range(len(bits) // 64):
             ecmd_buf.setDoubleWord(i, bits[i*64:(i+1)*64].uint)
         return ecmd_buf
     if isinstance(buf, (str, unicode)):


### PR DESCRIPTION
Other code might depend on os.path[0] being the path of the executed
script, and there is no need for our new path to be at the front.