### PR TITLE
Fix crash when getting command help text with network.dll

### DIFF
--- a/dllNetwork/ecmdDllNetwork.C
+++ b/dllNetwork/ecmdDllNetwork.C
@@ -372,7 +372,7 @@ uint32_t dllQueryFileLocationHidden2(const ecmdChipTarget & i_target, ecmdFileTy
     if (i_fileType == ECMD_FILE_HELPTEXT) {
         char directoryName[200];
         sprintf(directoryName, "%s/../../help/", dirname(getenv("ECMD_EXE")));
-        o_fileLocations.push_back((ecmdFileLocation){ directoryName, NULL });
+        o_fileLocations.push_back((ecmdFileLocation){ directoryName, "" });
     }
 
     return ECMD_SUCCESS;


### PR DESCRIPTION
Passing -h to an eCMD command from the shell causes a crash:

$ geti2c -h
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
eCMD/install/bin/geti2c: line 37: 23757 Aborted                 (core dumped) $ecmd_exe $filename "$@"

Commit 51ada0d: "C API: Add ecmdQueryFileLocationHidden2() using
custom struct instead of std::pair" modified this feature to use a
list<ecmdFileLocation> rather than a single string to hold the path
information and the hash. However, the NULL argument does not work if
there is no hash to use. Switch to an empty string instead.

Signed-off-by: Ryan King <rpking@us.ibm.com>