### PR TITLE
Output correct offset from server debug for I2C with 8-byte offsets

### DIFF
--- a/dllNetwork/server/I2CInstruction.C
+++ b/dllNetwork/server/I2CInstruction.C
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <iomanip>
 #include <errno.h>
+#include <inttypes.h>
 
 #include <OutputLite.H>
 extern OutputLite out;
@@ -270,7 +271,14 @@ uint32_t I2CInstruction::execute(ecmdDataBuffer & o_data, InstructionStatus & o_
         errno = 0;
 
         if (flags & INSTRUCTION_FLAG_SERVER_DEBUG) {
-          snprintf(errstr, 200, "SERVER_DEBUG : iic_config_device_offset() offset = 0x%08X\n", offset);
+          if (offsetFieldSize > 4)
+          {
+            snprintf(errstr, 200, "SERVER_DEBUG : iic_config_device_offset() address = 0x%0" PRIx64 "\n", address);
+          }
+          else
+          {
+            snprintf(errstr, 200, "SERVER_DEBUG : iic_config_device_offset() offset = 0x%08X\n", offset);
+          }
           o_status.errorMessage.append(errstr);
         }
 


### PR DESCRIPTION
Commit 172df96 (Enable 8-byte offsets for I2C) stores the 8-byte
offset in the 'address' variable, rather than the 'offset' variable
used for 4-byte offsets. Update the debug message to do the same check
to output the correct variable.

The correct printf formatting string for a 64-bit value varies between
systems (%016lX or %016llX, for example), so pull in the PRIx64 macro from
inttypes.h.

Signed-off-by: Ryan King <rpking@us.ibm.com>