### PR TITLE
Return the git hash for `croquery serverversion`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ makefile.override
 # We want to ignore any sub ecmd-* dirs, except the included ecmd-core
 ecmd-*
 !ecmd-core
+
+# Ignore auto-generated git version files
+/dllNetwork/server/git_version.C

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,3 @@ makefile.override
 # We want to ignore any sub ecmd-* dirs, except the included ecmd-core
 ecmd-*
 !ecmd-core
-
-# Ignore auto-generated git version files
-/dllNetwork/server/git_version.C

--- a/dllNetwork/server/ControlInstruction.C
+++ b/dllNetwork/server/ControlInstruction.C
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <git_version.H>
 
 #ifdef OTHER_USE
 #include <OutputLite.H>
@@ -282,6 +283,7 @@ uint32_t ControlInstruction::execute(ecmdDataBuffer & o_data, InstructionStatus 
         std::ostringstream oss;
         oss << "Server Version" << std::endl;
         oss << "Date: " << __DATE__ << " " << __TIME__ << std::endl;
+        oss << "Git Version: " << git_version << std::endl;
         std::map<std::string, uint32_t>::iterator versionIterator = controls->global_version_map_pointer->begin();
         while (versionIterator != controls->global_version_map_pointer->end()) {
           oss << std::left << std::setw(24) << versionIterator->first << " : " << versionIterator->second << std::endl;

--- a/dllNetwork/server/git_version.H
+++ b/dllNetwork/server/git_version.H
@@ -1,0 +1,4 @@
+#ifndef _GIT_VERSION_H
+#define _GIT_VERSION_H
+extern const char *git_version;
+#endif // _GIT_VERSION_H

--- a/dllNetwork/server/makefile
+++ b/dllNetwork/server/makefile
@@ -82,8 +82,7 @@ LDFLAGS += -ldl -lpthread -lz
 all:
 	${run-all}
 
-generate:
-  # Do nothing
+generate: git_version.C
 
 build: ${TARGET}
 
@@ -127,7 +126,7 @@ ${TGT_SOURCE_C_OBJS}: ${OBJPATH}%.o : %.c ${INCLUDES}
 ../../.git/HEAD:
 ../../.git/index:
 git_version.C: ../../.git/HEAD ../../.git/index
-	@echo "const char *git_version = \"$(shell git describe --dirty --always --tags)\";" > $@
+	@echo "const char *git_version = \"$(shell git describe --dirty --always --tags)\";" > ${SRCPATH}/$@
 
 # *****************************************************************************
 # Create the Target

--- a/dllNetwork/server/makefile
+++ b/dllNetwork/server/makefile
@@ -39,6 +39,7 @@ TGT_INCLUDES += PNORInstruction.H
 TGT_INCLUDES += fd_impl.H
 TGT_INCLUDES += ServerSBEFIFOInstruction.H
 TGT_INCLUDES += SBEFIFOInstruction.H
+TGT_INCLUDES += git_version.H
 
 TGT_SOURCE := Instruction.C
 TGT_SOURCE += InstructionStatus.C
@@ -57,6 +58,7 @@ TGT_SOURCE += PNORInstruction.C
 TGT_SOURCE += fd_impl.C
 TGT_SOURCE += ServerSBEFIFOInstruction.C
 TGT_SOURCE += SBEFIFOInstruction.C
+TGT_SOURCE += git_version.C
 TGT_SOURCE += server1p.C
 
 TGT_SOURCE_C := adal_base.c
@@ -114,6 +116,18 @@ ${TGT_SOURCE_OBJS}: ${OBJPATH}%.o : %.C ${INCLUDES}
 ${TGT_SOURCE_C_OBJS}: ${OBJPATH}%.o : %.c ${INCLUDES}
 	@echo Compiling $<
 	${VERBOSE}${CXX} -c ${CXXFLAGS} $< -o $@ ${DEFINES}
+
+# *****************************************************************************
+# Create a .C file containing the git hash to print out as part of the
+# serverversion. If we are building from a .zip download, the .git
+# folder doesn't exist. Create empty targets for the .git folder so
+# make doesn't try to create them. If we build in this situation, the
+# version is an empty string, which is the best we can do.
+# *****************************************************************************
+../../.git/HEAD:
+../../.git/index:
+git_version.C: ../../.git/HEAD ../../.git/index
+	@echo "const char *git_version = \"$(shell git describe --dirty --always --tags)\";" > $@
 
 # *****************************************************************************
 # Create the Target


### PR DESCRIPTION
We accomplish this by adding a makefile target to generate a .C file
if the description of HEAD changes. Because the added header file
remains unchanged if the commit changes, this doesn't require a mass
rebuild of the other files. Only git_version.o needs to be rebuilt.

Instead of printing out the entire hash directly, we print out the
most recent tag, an abbreviated hash, and a -dirty flag if
needed. `croquery serverversion` now returns something similar to:

...
Server Version
Date: May  6 2019 20:24:14
Git Version: ver-14-15-1-24-gedf2004
ControlInstruction       : 4
...

If building from a .zip download, the .git directory doesn't exist and
we have no way of knowing what commit we are on. Output a blank
version string in this case. Due to how the makefile was updated, the
git_version.C target is run every time in this situation, while it
only runs if the hash changes when cloning via git.

Signed-off-by: Ryan King <rpking@us.ibm.com>