### PR TITLE
Updated getChipletNumber with missing chip unit types.

### DIFF
--- a/ecmd-core/ext/fapi2/capi/target.H
+++ b/ecmd-core/ext/fapi2/capi/target.H
@@ -468,7 +468,13 @@ Target<K, M, V>::getChipletNumber(void) const
               (l_pEcmdTarget->chipUnitType == "mc") ||
               (l_pEcmdTarget->chipUnitType == "omi") ||
               (l_pEcmdTarget->chipUnitType == "omic") ||
-              (l_pEcmdTarget->chipUnitType == "mcc")) &&
+              (l_pEcmdTarget->chipUnitType == "mcc") ||
+              (l_pEcmdTarget->chipUnitType == "nmmu") ||
+              (l_pEcmdTarget->chipUnitType == "pau") ||
+              (l_pEcmdTarget->chipUnitType == "iohs") ||
+              (l_pEcmdTarget->chipUnitType == "fc") ||
+              (l_pEcmdTarget->chipUnitType == "pauc") ||
+              (l_pEcmdTarget->chipUnitType == "ppe")) &&
              (l_pEcmdTarget->chipUnitNumState == ECMD_TARGET_FIELD_VALID))
     {
         std::list<const ecmdChipTarget*> l_targets;


### PR DESCRIPTION
Signed-off-by: Kahn Evans <kahnevan@us.ibm.com>

I think I got all the necessary chip units added to this.