### PR TITLE
Fix undefined git_version symbol in dllNetwork

### DIFF
--- a/dllNetwork/makefile
+++ b/dllNetwork/makefile
@@ -20,8 +20,8 @@ VPATH        := ${VPATH}:${ECMD_ROOT}/ecmd-core/capi:${ECMD_ROOT}/ecmd-core/dll:
 ECMD_INCLUDES := ecmdClientCapi.H ecmdDataBuffer.H ecmdReturnCodes.H ecmdStructs.H ecmdUtils.H ecmdClientEnums.H ecmdSharedUtils.H ecmdDefines.H
 
 # The source files and includes in our local dirs that are going into the build
-TGT_INCLUDES  := ecmdDllCapi.H eth_transfer1.h transfer.h OutputLite.H ecmdTransfer.H Controller.H fd_impl.H Instruction.H InstructionStatus.H FSIInstruction.H GPIOInstruction.H I2CInstruction.H ControlInstruction.H InstructionFlag.H PNORInstruction.H
-TGT_SOURCE    := ecmdDllCapi.C ecmdDllNetwork.C ecmdDllNetworkInfo.C eth_transfer1.C OutputLite.C ecmdTransfer.C Controller.C fd_impl.C Instruction.C InstructionStatus.C FSIInstruction.C GPIOInstruction.C I2CInstruction.C ControlInstruction.C InstructionFlag.C PNORInstruction.C
+TGT_INCLUDES  := ecmdDllCapi.H eth_transfer1.h transfer.h OutputLite.H ecmdTransfer.H Controller.H fd_impl.H Instruction.H InstructionStatus.H FSIInstruction.H GPIOInstruction.H I2CInstruction.H ControlInstruction.H InstructionFlag.H PNORInstruction.H git_version.H
+TGT_SOURCE    := ecmdDllCapi.C ecmdDllNetwork.C ecmdDllNetworkInfo.C eth_transfer1.C OutputLite.C ecmdTransfer.C Controller.C fd_impl.C Instruction.C InstructionStatus.C FSIInstruction.C GPIOInstruction.C I2CInstruction.C ControlInstruction.C InstructionFlag.C PNORInstruction.C git_version.C
 
 # Combine all the includes into one variable for the build
 INCLUDES      := ${ECMD_INCLUDES} ${TGT_INCLUDES}
@@ -37,7 +37,7 @@ all:
 	${run-all}
 
 generate:
-  # Do nothing
+	$(MAKE) --directory=server $@
 
 build: ${TARGET}
         # Remove the object after each build to force a rebuild


### PR DESCRIPTION
Commit 356569b ("Return the git hash for `croquery serverversion`")
added a dependency of server/ControlInstruction.C on
git_version.C. However, server/ControlInstruction.C is also used in
dllNetwork. Because git_version.C isn't used when compiling
dllNetwork, there is a runtime error when attempting to use the
resulting network.dll.

ERROR: loadDll: Problems loading eCMD/out_x86_64/lib/network.dll : eCMD/out_x86_64/lib/network.dll: undefined symbol: git_version
dllLoadDllRecovery: eCMD Function called before DLL has been loaded

Resolve this issue by calling the generate target of server when
building dllNetwork in order to create the necessary git_version.C.