### PR TITLE
Fix crash when getting command help text with network.dll

### DIFF
--- a/dllNetwork/ecmdDllNetwork.C
+++ b/dllNetwork/ecmdDllNetwork.C
@@ -350,7 +350,7 @@ uint32_t dllQueryFileLocation(const ecmdChipTarget & i_target, ecmdFileType_t i_
     if (i_fileType == ECMD_FILE_HELPTEXT) {
         char directoryName[200];
         sprintf(directoryName, "%s/../../help/", dirname(getenv("ECMD_EXE")));
-        o_fileLocations.push_back((ecmdFileLocation){ directoryName, NULL });
+        o_fileLocations.push_back((ecmdFileLocation){ directoryName, "" });
     }
 
     return ECMD_SUCCESS;


### PR DESCRIPTION
Signed-off-by: Kahn Evans <kahnevan@us.ibm.com>