### PR TITLE
fix for using PRIx64 formatting

### DIFF
--- a/dllNetwork/server/I2CInstruction.C
+++ b/dllNetwork/server/I2CInstruction.C
@@ -21,6 +21,9 @@
 //--------------------------------------------------------------------
 // Includes
 //--------------------------------------------------------------------
+#ifndef __STDC_FORMAT_MACROS
+  #define __STDC_FORMAT_MACROS 1
+#endif
 #include <I2CInstruction.H>
 #include <arpa/inet.h>
 #include <stdio.h>


### PR DESCRIPTION
add check for __STDC_FORMAT_MACROS define
Signed-off-by: Kahn Evans <kahnevan@us.ibm.com>