### PR TITLE
Add ecmdChipTarget hash support to pyapi

### DIFF
--- a/ecmd-core/pyapi/ecmdClientPyapi.i
+++ b/ecmd-core/pyapi/ecmdClientPyapi.i
@@ -112,6 +112,23 @@
 %copyctor ecmdLooperData;
 /*********** End Copy Constructors ***********/
 
+/*********** Start Extend ***********/
+// Add a hash function to the ecmdChipTarget
+// This allows it to be used as a dict key, etc..
+// Use all the values of the ecmdChipTarget in the hash generation for uniqueness
+%extend ecmdChipTarget {
+%pythoncode %{
+def __hash__(self):
+    return hash((self.cage, self.cageState, self.node, self.nodeState,
+                 self.slot, self.slotState,
+                 self.pos, self.posState, self.chipType, self.chipTypeState,
+                 self.chipUnitNum, self.chipUnitNumState,
+                 self.chipUnitType, self.chipUnitTypeState,
+                 self.thread, self.threadState))
+%}
+}
+/*********** End Extend ***********/
+
 /*********** Start Map to Bytearray ***********/
 // These apply the insert/extract/memCopyIn/memCopyOut functions in the edb
 %pybuffer_mutable_string(uint8_t * o_data);

--- a/ecmd-core/pyapi/testBuild.py
+++ b/ecmd-core/pyapi/testBuild.py
@@ -126,6 +126,20 @@ if (rc):
 else:
     print("Unit Id Version: %08x" % unitIdVer)
 
+# Make sure target hashing is working
+# If it is working, we can setup two different targets with the same states
+# The 2nd target should be able to access what was loaded for the 1st target
+# If it breaks, the target2 access will throw a key error
+target1 = ecmd.ecmdChipTarget()
+target2 = ecmd.ecmdChipTarget()
+target1.cageState = ecmd.ECMD_TARGET_FIELD_VALID
+target2.cageState = ecmd.ECMD_TARGET_FIELD_VALID
+targets = dict()
+targets[target1] = "hi"
+
+if (targets[target2] != "hi"):
+    print("ERROR: target hashing broke!")
+
 # Pulling this test for now
 # It breaks builds where ring support isn't included, so some smarts would need to be put into it
 # JTA 11/11/2014


### PR DESCRIPTION
Without a __hash__ function, the ecmdChipTarget can't be used
as a key to a dictionary.  Defining the __hash__ function fixes
that issue.

Signed-off-by: Kahn Evans <kahnevan@us.ibm.com>