### PR TITLE
Support for --firstinc build option

### DIFF
--- a/config.py
+++ b/config.py
@@ -82,6 +82,10 @@ optgroup.add_argument("--cxx_r", help="The reentrant compiler to use (AIX only)\
 optgroup.add_argument("--cxxflags", help="Any CXXFLAGS to use in the build\n"
                                          "CXXFLAGS from the environment")
 
+# --firstinc
+optgroup.add_argument("--firstinc", help="Set the first include path (-I) to be defined\n"
+                                         "in CXXFLAGS and SWIGFLAGS")
+
 # --ld
 optgroup.add_argument("--ld", help="The linker to use\n"
                                    "LD from the environment")
@@ -563,6 +567,13 @@ elif ("CXXFLAGS" in os.environ):
 # Common compile flags across any OS
 CXXFLAGS += " -g -I."
 
+# If the option was given, make sure the given path is
+# at the front of the list
+if (args.firstinc):
+    firstinc = " -I%s" % args.firstinc
+    CXXFLAGS += firstinc
+    SWIGFLAGS = firstinc
+
 # If the user passed thru extra defines, grab them
 if "DEFINES" in os.environ:
     DEFINES = os.environ["DEFINES"]
@@ -595,6 +606,8 @@ buildvars["GPATH"] = GPATH
 buildvars["CXXFLAGS"] = CXXFLAGS
 buildvars["LDFLAGS"] = LDFLAGS
 buildvars["SLDFLAGS"] = SLDFLAGS
+if (SWIGFLAGS):
+    buildvars["SWIGFLAGS"] = SWIGFLAGS
 
 ###################################
 # Setup for creating SWIG outputs #

--- a/ecmd-core/cmd/ecmdJtagUser.C
+++ b/ecmd-core/cmd/ecmdJtagUser.C
@@ -17,7 +17,6 @@
  */
 //IBM_PROLOG_END_TAG
 
-#ifndef ECMD_REMOVE_JTAG_FUNCTIONS
 //----------------------------------------------------------------------
 //  Includes
 //----------------------------------------------------------------------
@@ -55,6 +54,7 @@
 // Member Function Specifications
 //---------------------------------------------------------------------
 
+#ifndef ECMD_REMOVE_JTAG_FUNCTIONS
 
 uint32_t ecmdSendCmdUser(int argc, char * argv[]) {
   uint32_t rc = ECMD_SUCCESS;

--- a/ecmd-core/cmd/ecmdScomUser.C
+++ b/ecmd-core/cmd/ecmdScomUser.C
@@ -58,6 +58,8 @@
 // Member Function Specifications
 //---------------------------------------------------------------------
 
+#ifndef ECMD_REMOVE_SCOM_FUNCTIONS
+
 uint32_t ecmdGetScomUser(int argc, char* argv[]) {
   uint32_t rc = ECMD_SUCCESS, coeRc = ECMD_SUCCESS;
   uint32_t e_rc = ECMD_SUCCESS;                 ///< Expect rc
@@ -1158,3 +1160,4 @@ uint32_t ecmdPollScomUser(int argc, char* argv[]) {
 
   return rc;
 }
+#endif //ECMD_REMOVE_SCOM_FUNCTIONS


### PR DESCRIPTION
In order for plugins to be able to take advantage of ecmdDefines.H they need to be able to define that file as the first thing in the include path.  This changeset allow for that to be done.

It also includes a couple minor fixes to allow ecmdDefines.H to function properly.