### PR TITLE
Defined __deepcopy__ functions on classes

### DIFF
--- a/ecmd-core/pyapi/ecmdClientPyapi.i
+++ b/ecmd-core/pyapi/ecmdClientPyapi.i
@@ -79,37 +79,235 @@
 /*********** End Templates ***********/
 
 /*********** Start Copy Constructors ***********/
+// We also define __deepcopy__ for each class here since
+// they also rely upon the copy constructors we are defining
 %copyctor ecmdChipTarget;
+%extend ecmdChipTarget {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdThreadData;
+%extend ecmdThreadData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdChipUnitData;
+%extend ecmdChipUnitData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdChipData;
+%extend ecmdChipData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdSlotData;
+%extend ecmdSlotData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdNodeData;
+%extend ecmdNodeData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdCageData;
+%extend ecmdCageData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdQueryData;
+%extend ecmdQueryData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdRingData;
+%extend ecmdRingData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdArrayData;
+%extend ecmdArrayData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdTraceArrayData;
+%extend ecmdTraceArrayData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdFastArrayData;
+%extend ecmdFastArrayData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdScomData;
+%extend ecmdScomData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdLataData;
+%extend ecmdLatchData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdScomEntry;
+%extend ecmdScomEntry {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdArrayEntry;
+%extend ecmdArrayEntry {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdNameEntry;
+%extend ecmdNameEntry {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdNameVectorEntry;
+%extend ecmdNameVectorEntry {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdIndexVectorEntry;
+%extend ecmdIndexVectorEntry {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdIndexEntry;
+%extend ecmdIndexEntry {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdLatchEntry;
+%extend ecmdLatchEntry {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdLatchQueryData;
+<<<<<<< HEAD
+=======
+%extend ecmdLatchQueryData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
+%copyctor ecmdLatchQueryDataHidden;
+%extend ecmdLatchQueryDataHidden {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
+>>>>>>> 6d349a26... Defined __deepcopy__ functions on classes
 %copyctor ecmdProcRegisterInfo;
+%extend ecmdProcRegisterInfo {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdCacheData;
+%extend ecmdCacheData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdSpyData;
+%extend ecmdSpyData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdI2CCmdEntry;
+%extend ecmdI2CCmdEntry {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdSimModelInfo;
+%extend ecmdSimModelInfo {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdConnectionData;
+%extend ecmdConnectionData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdPnorListEntryData;
+%extend ecmdPnorListEntryData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdPnorListData;
+%extend ecmdPnorListData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 %copyctor ecmdLooperData;
+%extend ecmdLooperData {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
+%}
+}
 /*********** End Copy Constructors ***********/
 
 /*********** Start Extend ***********/
@@ -125,6 +323,14 @@ def __hash__(self):
                  self.chipUnitNum, self.chipUnitNumState,
                  self.chipUnitType, self.chipUnitTypeState,
                  self.thread, self.threadState))
+%}
+}
+
+// Define a __deepcopy__ for the databuffer using its copy constructor
+%extend ecmdDataBuffer {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.__init__(self)
 %}
 }
 /*********** End Extend ***********/

--- a/ecmd-core/pyapi/testBuild.py
+++ b/ecmd-core/pyapi/testBuild.py
@@ -2,6 +2,7 @@
 import ecmd
 import os
 import sys
+import copy
 
 # Create our test number variable
 # It will be incremented after each test that executes
@@ -139,6 +140,13 @@ targets[target1] = "hi"
 
 if (targets[target2] != "hi"):
     print("ERROR: target hashing broke!")
+
+# A couple deepcopy tests to make sure the defined __deepcopy__ functions work
+# If not, we'll take a traceback and the test will fail
+edborig = ecmd.ecmdDataBuffer()
+targetorig = ecmd.ecmdChipTarget()
+edbcopy = copy.deepcopy(edborig)
+targetcopy = copy.deepcopy(targetorig)
 
 # Pulling this test for now
 # It breaks builds where ring support isn't included, so some smarts would need to be put into it


### PR DESCRIPTION
We are unable to use pythons copy.deepcopy by default on our
swig'd classes.  By defining __deepcopy__ functions on each class,
we can use their copy constructor to enable copy.deepcopy

Signed-off-by: Jason Albert <albertj@us.ibm.com>