### PR TITLE
Added ECMD_DLL_FILE_FIXED support

### DIFF
--- a/ecmd-core/capi/ecmdClientCapi.C
+++ b/ecmd-core/capi/ecmdClientCapi.C
@@ -140,8 +140,15 @@ uint32_t ecmdLoadDll(std::string i_dllName) {
     if (tempptr != NULL) {
       loadDllName = tempptr;
     } else {
+#ifdef ECMD_DEFAULT_DLL_FILE
+      // If compiled with the ECMD_DEFAULT_DLL_FILE define, we take that as the dll to use
+      // if not overriden by the ECMD_DLL_FILE variable
+      loadDllName = ECMD_DEFAULT_DLL_FILE;
+#else
+      // If not compiled with a default, throw an error to the user
       fprintf(stderr,"ecmdLoadDll: Unable to find DLL to load, you must set ECMD_DLL_FILE\n");
       return ECMD_INVALID_DLL_FILENAME;
+#endif
     }
   }
 

--- a/ecmd-core/capi/ecmdClientCapi.C
+++ b/ecmd-core/capi/ecmdClientCapi.C
@@ -140,10 +140,12 @@ uint32_t ecmdLoadDll(std::string i_dllName) {
     if (tempptr != NULL) {
       loadDllName = tempptr;
     } else {
-#ifdef ECMD_DEFAULT_DLL_FILE
-      // If compiled with the ECMD_DEFAULT_DLL_FILE define, we take that as the dll to use
-      // if not overriden by the ECMD_DLL_FILE variable
-      loadDllName = ECMD_DEFAULT_DLL_FILE;
+#ifdef ECMD_DLL_FILE_FIXED
+      // If compiled with the ECMD_DLL_FILE_FIXED define, we take that as the dll to use
+      // if not overriden by the ECMD_DLL_FILE env variable
+      // This is useful to prevent having to set environment variables in static environments
+      // A sample usage of this variable on a cmdline compile would be: -DECMD_DLL_FILE_FIXED=\"plugin.dll\"
+      loadDllName = ECMD_DLL_FILE_FIXED;
 #else
       // If not compiled with a default, throw an error to the user
       fprintf(stderr,"ecmdLoadDll: Unable to find DLL to load, you must set ECMD_DLL_FILE\n");


### PR DESCRIPTION
This allows an at build time definition of the ECMD_DLL_FILE to
load.  This removes the need for the ECMD_DLL_FILE to be set in
the environment.

This is designed for static install situations where the location
of the libraries doesn't change.  However, it still supports the
use setting ECMD_DLL_FILE if needed.

Signed-off-by: Jason Albert <albertj@us.ibm.com>