### PR TITLE
Fixed config.py issue with SWIGFLAGS

### DIFF
--- a/config.py
+++ b/config.py
@@ -569,6 +569,7 @@ CXXFLAGS += " -g -I."
 
 # If the option was given, make sure the given path is
 # at the front of the list
+SWIGFLAGS = None
 if (args.firstinc):
     firstinc = " -I%s" % args.firstinc
     CXXFLAGS += firstinc


### PR DESCRIPTION
There were cases where SWIGFLAGS would be undefined and then
the script would fail at a later reference to it.

Signed-off-by: Jason Albert <albertj@us.ibm.com>