### PR TITLE
Adding spy APIs to pass in multiple images.

### DIFF
--- a/ecmd-core/capi/ecmdClientCapi.H
+++ b/ecmd-core/capi/ecmdClientCapi.H
@@ -492,6 +492,21 @@ uint32_t ecmdQueryArray(const ecmdChipTarget & i_target, std::list<ecmdArrayData
  TARGET STATES : Unused<br>
 */
 uint32_t ecmdQuerySpy(const ecmdChipTarget & i_target, std::list<ecmdSpyData> & o_queryData, const char * i_spyName = NULL, ecmdQueryDetail_t i_detail = ECMD_QUERY_DETAIL_HIGH);
+
+/**
+ @brief Determine all rings associated with spy - including any rings from associated parity checkers
+ @param i_target Struct that specifies the target to operate on (see target depth and states below)
+ @param i_spyName Name of spy to get associated ring names for 
+ @param o_ringNames Returned list of rings associated with spy 
+ @retval ECMD_TARGET_NOT_CONFIGURED if target is not available in the system
+ @retval ECMD_SUCCESS if successful
+ @retval ECMD_INVALID_SPY if spy name is not valid for target
+ @retval nonzero on failure
+
+ TARGET DEPTH  : pos<br>
+ TARGET STATES : Unused<br>
+*/
+uint32_t ecmdQuerySpyRings(const ecmdChipTarget & i_target, const char * i_spyName, std::list<std::string> & o_ringNames);
 #endif // ECMD_REMOVE_SPY_FUNCTIONS
 
 #ifndef ECMD_REMOVE_SCOM_FUNCTIONS
@@ -1210,6 +1225,55 @@ uint32_t getSpyImage(const ecmdChipTarget & i_target, const char * i_spyName, co
 uint32_t getSpyEnumImage(const ecmdChipTarget & i_target, const char * i_spyName, const ecmdDataBuffer & i_ringImage, std::string & o_enumValue);
 
 /**
+ @brief Reads the selected spy into the data buffer from provided ring images
+ @retval ECMD_TARGET_NOT_CONFIGURED if target is not available in the system
+ @retval ECMD_SPY_FAILED_ECC_CHECK if invalid ECC detected on Spy read
+ @retval ECMD_INVALID_SPY Spy name is invalid or Spy is an ECC Grouping
+ @retval ECMD_CLOCKS_IN_INVALID_STATE Chip Clocks were in an invalid state to perform the operation
+ @retval ECMD_SPY_IS_EDIAL Spy is an edial have to use getSpyEnum
+ @retval ECMD_SPY_GROUP_MISMATCH A mismatch was found reading a group spy not all groups set the same
+ @retval ECMD_MULTIPLE_RING_IMAGE_SPY Spy spans multiple rings and not enough or incorrect ring images were input
+ @retval ECMD_SUCCESS if successful read
+ @retval nonzero if unsuccessful
+ @param i_target Struct that specifies the target to operate on (see target depth and states below)
+ @param i_spyName Name of spy to read from
+ @param i_ringImages Map of ring names and corresponding DataBuffer objects that hold the ring images used by the requested spy (Buffer must be of the correct length).
+ @param o_data DataBuffer object that holds data read from spy
+
+ NOTE : This function is ring cache enabled<br>
+ NOTE : The rings associated with the spy can be retrieved by calling ecmdQuerySpyRings.<br>
+ TARGET DEPTH  : pos, chipUnit<br>
+ TARGET STATES : Unused<br>
+
+*/
+uint32_t getSpyImages(const ecmdChipTarget & i_target, const char * i_spyName, const std::map<std::string, ecmdDataBuffer> & i_ringImages, ecmdDataBuffer & o_data);
+
+/**
+ @brief Reads the selected spy and returns it's assocaiated enum from provided ring images
+ @retval ECMD_TARGET_NOT_CONFIGURED if target is not available in the system
+ @retval ECMD_SPY_FAILED_ECC_CHECK if invalid ECC detected on Spy read - valid Spy Data still returned
+ @retval ECMD_INVALID_SPY Spy name is invalid or Spy is an ECC Grouping
+ @retval ECMD_INVALID_SPY_ENUM if value in hardware doesn't map to a valid enum
+ @retval ECMD_SPY_NOT_ENUMERATED Spy is not enumerated must use getSpy
+ @retval ECMD_SPY_GROUP_MISMATCH A mismatch was found reading a group spy not all groups set the same
+ @retval ECMD_CLOCKS_IN_INVALID_STATE Chip Clocks were in an invalid state to perform the operation
+ @retval ECMD_MULTIPLE_RING_IMAGE_SPY Spy spans multiple rings and not enough or incorrect ring images were input
+ @retval ECMD_SUCCESS if successful read
+ @retval nonzero if unsuccessful
+ @param i_target Struct that specifies the target to operate on (see target depth and states below)
+ @param i_spyName Name of spy to read from
+ @param i_ringImages Map of ring names and corresponding DataBuffer objects that hold the ring images used by the requested spy (Buffer must be of the correct length).
+ @param o_enumValue Enum value read from the spy
+
+ NOTE : This function is ring cache enabled<br>
+ NOTE : The rings associated with the spy can be retrieved by calling ecmdQuerySpyRings.<br>
+ TARGET DEPTH  : pos, chipUnit<br>
+ TARGET STATES : Unused<br>
+
+*/
+uint32_t getSpyEnumImages(const ecmdChipTarget & i_target, const char * i_spyName, const std::map<std::string, ecmdDataBuffer> & i_ringImages, std::string & o_enumValue);
+
+/**
  @brief Writes the data buffer into the selected spy within the provided ring image
  @retval ECMD_TARGET_NOT_CONFIGURED if target is not available in the system
  @retval ECMD_SUCCESS if successful
@@ -1236,7 +1300,7 @@ uint32_t putSpyImage(const ecmdChipTarget & i_target, const char * i_spyName, co
  @retval ECMD_TARGET_NOT_CONFIGURED if target is not available in the system
  @retval ECMD_SUCCESS if successful
  @retval ECMD_INVALID_SPY Spy name is invalid or Spy is an ECC Grouping
- 2retval ECMD_SPY_NOT_ENUMERATED Spy is not enumerated must use putSpy
+ @retval ECMD_SPY_NOT_ENUMERATED Spy is not enumerated must use putSpy
  @retval ECMD_INVALID_SPY_ENUM if enum value specified is not valid
  @retval ECMD_CLOCKS_IN_INVALID_STATE Chip Clocks were in an invalid state to perform the operation
  @retval nonzero if unsuccessful
@@ -1250,7 +1314,55 @@ uint32_t putSpyImage(const ecmdChipTarget & i_target, const char * i_spyName, co
  TARGET STATES : Unused<br>
 
 */
+
 uint32_t putSpyEnumImage(const ecmdChipTarget & i_target, const char * i_spyName, const std::string i_enumValue, ecmdDataBuffer & io_ringImage);
+
+/**
+ @brief Writes the data buffer into the selected spy within the provided ring images
+ @retval ECMD_TARGET_NOT_CONFIGURED if target is not available in the system
+ @retval ECMD_SUCCESS if successful
+ @retval ECMD_INVALID_SPY Spy name is invalid or Spy is an ECC Grouping
+ @retval ECMD_DATA_OVERFLOW Too much data was provided for a write
+ @retval ECMD_DATA_UNDERFLOW  Too little data was provided to a write function
+ @retval ECMD_CLOCKS_IN_INVALID_STATE Chip Clocks were in an invalid state to perform the operation
+ @retval ECMD_SPY_IS_EDIAL Spy is an edial have to use putSpyEnum
+ @retval ECMD_MULTIPLE_RING_IMAGE_SPY Spy spans multiple rings and not enough or incorrect ring images were input
+ @retval nonzero if unsuccessful
+ @param i_target Struct that specifies the target to operate on (see target depth and states below)
+ @param i_spyName Name of spy to write to
+ @param i_data DataBuffer object that holds data to write into spy
+ @param io_ringImages Map of ring names and cooresponding DataBuffer objects that hold the ring images used by the requested spy (Buffer must be of the correct length).
+
+ NOTE : This function is ring cache enabled<br>
+ NOTE : The rings associated with the spy can be retrieved by calling ecmdQuerySpyRings.<br>
+ TARGET DEPTH  : pos, chipUnit<br>
+ TARGET STATES : Unused<br>
+
+*/
+uint32_t putSpyImages(const ecmdChipTarget & i_target, const char * i_spyName, ecmdDataBuffer & i_data, std::map<std::string, ecmdDataBuffer> & io_ringImages);
+
+/**
+ @brief Writes the enum into the selected spy within the provided ring images
+ @retval ECMD_TARGET_NOT_CONFIGURED if target is not available in the system
+ @retval ECMD_SUCCESS if successful
+ @retval ECMD_INVALID_SPY Spy name is invalid or Spy is an ECC Grouping
+ @retval ECMD_SPY_NOT_ENUMERATED Spy is not enumerated must use putSpy
+ @retval ECMD_INVALID_SPY_ENUM if enum value specified is not valid
+ @retval ECMD_CLOCKS_IN_INVALID_STATE Chip Clocks were in an invalid state to perform the operation
+ @retval ECMD_MULTIPLE_RING_IMAGE_SPY Spy spans multiple rings and not enough or incorrect ring images were input
+ @retval nonzero if unsuccessful
+ @param i_target Struct that specifies the target to operate on (see target depth and states below)
+ @param i_spyName Name of spy to write to
+ @param i_enumValue String enum value to load into the spy
+ @param io_ringImages Map of ring names and corresponding DataBuffer objects that hold the ring images used by the requested spy (Buffer must be of the correct length).
+
+ NOTE : This function is ring cache enabled<br>
+ NOTE : The rings associated with the spy can be retrieved by calling ecmdQuerySpyRings.<br>
+ TARGET DEPTH  : pos, chipUnit<br>
+ TARGET STATES : Unused<br>
+
+*/
+uint32_t putSpyEnumImages(const ecmdChipTarget & i_target, const char * i_spyName, const std::string i_enumValue, std::map<std::string, ecmdDataBuffer> & io_ringImages);
 
 #endif // ECMD_REMOVE_SPY_FUNCTIONS
 //@}

--- a/ecmd-core/capi/ecmdReturnCodes.H
+++ b/ecmd-core/capi/ecmdReturnCodes.H
@@ -54,6 +54,7 @@
 #define ECMD_UNKNOWN_HELP_FILE                  (ECMD_ERR_ECMD | 0x1014) ///< Helpfile could not be read
 #define ECMD_INVALID_ARGS                       (ECMD_ERR_ECMD | 0x1015) ///< Not enough arguments provided to the function
 #define ECMD_INVALID_SPY_ENUM                   (ECMD_ERR_ECMD | 0x1017) ///< getSpyEnum or putSpyEnum used an invalid enum
+#define ECMD_MULTIPLE_RING_IMAGE_SPY            (ECMD_ERR_ECMD | 0x1018) ///< Spy spans multiple rings and not enough or incorrect ring images were input
 #define ECMD_SPY_FAILED_ECC_CHECK               (ECMD_ERR_ECMD | 0x1019) ///< getSpy or getSpyEnum failed with invalid ECC detected in the hardware
 #define ECMD_SPY_NOT_ENUMERATED                 (ECMD_ERR_ECMD | 0x101B) ///< getSpyEnum or putSpyEnum was called on a non-enumerated spy
 #define ECMD_SPY_IS_EDIAL                       (ECMD_ERR_ECMD | 0x101D) ///< getSpy or Putspy was called on an edial

--- a/ecmd-core/capi/ecmdStructs.H
+++ b/ecmd-core/capi/ecmdStructs.H
@@ -32,6 +32,7 @@
 #include <list>  /* For STL list */
 #include <vector>
 #include <string>
+#include <map>
 
 #include <ecmdDefines.H>
 #include <ecmdDataBuffer.H>

--- a/ecmd-core/cmd/ecmdSpyUser.C
+++ b/ecmd-core/cmd/ecmdSpyUser.C
@@ -1242,8 +1242,15 @@ uint32_t ecmdGetSpyImageUser(int argc, char * argv[]) {
         rc = getSpyImage(cuTarget, spyName.c_str(), ringImage,spyBuffer);
       }
       if (rc) {
-        printed = "getspyimage - Error occured performing getspyimage on ";
-        printed += ecmdWriteTarget(cuTarget) + "\n";
+        if (rc == ECMD_MULTIPLE_RING_IMAGE_SPY)
+        {
+            printed = "getspyimage - Command line support for multiple ring images is not supported.  You must use the APIs.\n";
+        }
+        else
+        {
+            printed = "getspyimage - Error occured performing getspyimage on ";
+            printed += ecmdWriteTarget(cuTarget) + "\n";
+        }
         ecmdOutputError( printed.c_str() );
         coeRc = rc;
         continue;
@@ -1494,8 +1501,15 @@ if (argc < 4 ) {  //chip + spy + ringimage +data
         rc = putSpyImage(cuTarget, spyName.c_str(),buffer, ringImage);
         }
         if (rc) {
-          printed = "putspyimage - Error occured performing putspyimage on ";
-          printed += ecmdWriteTarget(cuTarget) + "\n";
+          if (rc == ECMD_MULTIPLE_RING_IMAGE_SPY)
+          {
+              printed = "putspyimage - Command line support for multiple ring images is not supported.  You must use the APIs.\n";
+          }
+          else
+          {
+              printed = "putspyimage - Error occured performing putspyimage on ";
+              printed += ecmdWriteTarget(cuTarget) + "\n";
+          }
           ecmdOutputError( printed.c_str() );
           coeRc = rc;
           continue;

--- a/ecmd-core/cmd/help/ecmdquery.htxt
+++ b/ecmd-core/cmd/help/ecmdquery.htxt
@@ -26,6 +26,10 @@ Syntax: ecmdquery <Mode> [Mode Options]
                         spys Chip [spyname] [-a#] [-k#] [-n#] [-s#] [-p#]
                             - Display all spys available (or the selected spy) for chip
 
+                        spyrings Chip spyname  [-a#] [-k#] [-n#] [-s#] [-p#]
+                            - Display all rings used by selected spy for chip
+                            - Includes rings used by associated in/out parity checkers
+
                         procregs Chip.ChipUnit [procregistername] [-a#] [-k#] [-n#] [-s#] [-p#]
                             - Display information on the proc regs (sprs, gprs, fprs,
                               etc) available for Chip.ChipUnit (ChipUnit required)

--- a/ecmd-core/perlapi/ecmdClientPerlapi.i
+++ b/ecmd-core/perlapi/ecmdClientPerlapi.i
@@ -7,6 +7,7 @@
 %include ecmdList.i
 %include ecmdCommon.i
 %include ecmdConst.i
+%include std_map.i
 /*********** End Typemaps ***********/
 
 /*********** Start Applies ***********/
@@ -82,6 +83,8 @@
 %template(listEcmdScomEntry)         std::list<ecmdScomEntry>;
 %template(listUint32_t)              std::list<uint32_t>;
 %template(vectorString)              std::vector<std::string>;
+// Template for maps
+%template(string_ecmdDataBufferMap)  std::map<std::string, ecmdDataBuffer>;
 /*********** End Templates ***********/
 
 /*********** Start Copy Constructors ***********/

--- a/ecmd-core/perlapi/ecmdPerlApiTypes.H
+++ b/ecmd-core/perlapi/ecmdPerlApiTypes.H
@@ -243,4 +243,11 @@ typedef ecmdI2CCmdEntryList ecmdI2CCmdEntryList;
  @see Vector
 */
 typedef ecmdDataBufferVector ecmdDataBufferVector;
+
+typedef Map Map;
+/**
+ @brief The perl version of the std::map<std::string, ecmdDataBuffer>
+*/
+typedef string_ecmdDataBufferMap string_ecmdDataBufferMap;
+
 #endif

--- a/ecmd-core/pyapi/ecmdClientPyapi.i
+++ b/ecmd-core/pyapi/ecmdClientPyapi.i
@@ -16,6 +16,7 @@
 %include stdint.i
 %include ecmdCommon.i
 %include ecmdConst.i
+%include std_map.i
 /*********** End Typemaps ***********/
 
 /*********** Start Applies ***********/
@@ -78,7 +79,8 @@
 %template(ecmdScomEntryList)         std::list<ecmdScomEntry>;
 %template(ecmdFileLocationList)      std::list<ecmdFileLocation>;
 %template(uint32_tList)              std::list<uint32_t>;
-/*********** End Templates ***********/
+// Template for maps
+%template(string_ecmdDataBufferMap)  std::map<std::string, ecmdDataBuffer>;
 
 /*********** Start Copy Constructors ***********/
 // We also define __deepcopy__ for each class here since

--- a/ecmd-core/pyapi/ecmdPyApiTypes.H
+++ b/ecmd-core/pyapi/ecmdPyApiTypes.H
@@ -255,4 +255,10 @@ typedef ecmdFileLocationList ecmdFileLocationList;
  @see List
 */
 typedef uint32_tList uint32_tList;
+
+typedef Map Map;
+/**
+ @brief The python version of the std::map<std::string, ecmdDataBuffer>
+*/
+typedef string_ecmdDataBufferMap string_ecmdDataBufferMap;
 #endif

--- a/mkscripts/makedll.pl
+++ b/mkscripts/makedll.pl
@@ -76,9 +76,9 @@ while (<IN>) {
     my ($type, $funcname) = split(/\s+/, $func);
     my @argnames = split(/,/, $args);
 
-    #join any split std::pair arguments
+    #join any split std::pair and std::map arguments
     foreach my $i (0..$#argnames) {
-      if ($argnames[$i] =~ /std::pair/) {
+      if ($argnames[$i] =~ /std::pair|std::map/) {
         $argnames[$i] = "$argnames[$i], $argnames[$i+1]";
         splice(@argnames, $i+1, 1);
       }

--- a/mkscripts/makepm.pl
+++ b/mkscripts/makepm.pl
@@ -129,9 +129,9 @@ if ($ARGV[1] =~ /ClientPerlapiFunc.C/ || $genAll) {
           my ($type, $funcname) = split(/\s+/, $func);
           my @argnames = split(/,/,$args);
 
-          #join any split std::pair arguments
+          #join any split std::pair or std::map arguments
           foreach my $i (0..$#argnames) {
-            if ($argnames[$i] =~ /std::pair/) {
+            if ($argnames[$i] =~ /std::pair|std::map/) {
               $argnames[$i] = "$argnames[$i], $argnames[$i+1]";
               splice(@argnames, $i+1, 1);
             }
@@ -216,7 +216,7 @@ if ($ARGV[1] =~ /ClientPerlapiIterators.H/ || $genAll) {
     my $codeDataType;
     foreach $fileLine (@fileLines) {
 
-      if (substr($fileLine,0,9) eq "%template") {
+      if ((substr($fileLine,0,9) eq "%template") && ($fileLine =~ /list|vector/))  {
 
         @fileLineArr = split(/\s+/, $fileLine);
         # Get the swig name out of the first half


### PR DESCRIPTION
Adding ecmdQuerySpyRings() API to get all rings associated with spy and its parity checkers
Signed-off-by: Kahn Evans <kahnevan@us.ibm.com>