### PR TITLE
Moved -D extension support to makefile.config

### DIFF
--- a/config.py
+++ b/config.py
@@ -86,6 +86,10 @@ optgroup.add_argument("--cxxflags", help="Any CXXFLAGS to use in the build\n"
 optgroup.add_argument("--firstinc", help="Set the first include path (-I) to be defined\n"
                                          "in CXXFLAGS and SWIGFLAGS")
 
+# --header-defines
+optgroup.add_argument("--header-defines", action='store_true',
+                      help="Rely on ecmdDefines.H to set extension defines")
+
 # --ld
 optgroup.add_argument("--ld", help="The linker to use\n"
                                    "LD from the environment")
@@ -605,6 +609,11 @@ elif (TARGET_BARCH == "arm"):
 # See if REMOVE_SIM is enabled from the cmdline
 if (args.remove_sim):
     DEFINES += " -DREMOVE_SIM"
+
+# Added the extension defines if not using the header
+if (not args.header_defines):
+    for ext in sorted(EXTENSIONS.split()):
+        DEFINES += " -DECMD_" + ext.upper() + "_EXTENSION_SUPPORT"
     
 # Export everything we defined
 buildvars["DEFINES"] = DEFINES

--- a/ecmd-core/cmd/makefile
+++ b/ecmd-core/cmd/makefile
@@ -40,7 +40,7 @@ VPATH  := ${VPATH}$(foreach ext, ${EXT_CMD},:${EXT_${ext}_PATH}/cmd/:${EXT_${ext
 VPATH  := ${VPATH}:${OBJPATH}:${SRCPATH}:${ECMD_CORE}/capi
 
 CXXFLAGS := ${CXXFLAGS} -I${ECMD_CORE}/capi -I${ECMD_CORE}/dll -I${SRCPATH}
-CXXFLAGS := ${CXXFLAGS} $(foreach ext, ${EXT_CMD},-I${EXT_${ext}_PATH}/cmd -I${EXT_${ext}_PATH}/capi -DECMD_$(shell echo ${ext} | tr "a-zA-Z" "A-Za-z")_EXTENSION_SUPPORT)
+CXXFLAGS := ${CXXFLAGS} $(foreach ext, ${EXT_CMD},-I${EXT_${ext}_PATH}/cmd -I${EXT_${ext}_PATH}/capi)
 
 # *****************************************************************************
 # Define our output files

--- a/ecmd-core/perlapi/makefile
+++ b/ecmd-core/perlapi/makefile
@@ -47,8 +47,8 @@ SOURCE    := ${SOURCE} $(foreach ext, ${EXT_PYAPI}, ${ext}ClientPerlapi.C ${ext}
 # Remove the fapiClientPerlapiFunc.C from the build, only will use fapiClientPerlapi.C which has the init extension
 SOURCE    := $(subst fapi2ClientPerlapiFunc.C,,${SOURCE})
 SOURCE    := $(subst fapiClientPerlapiFunc.C,,${SOURCE})
-CXXFLAGS  := ${CXXFLAGS} $(foreach ext, ${EXT_PYAPI},-I${EXT_${ext}_PATH}/capi -I${EXT_${ext}_PATH}/perlapi -DECMD_$(shell echo ${ext} | tr "a-zA-Z" "A-Za-z")_EXTENSION_SUPPORT)
-SWIGFLAGS := ${SWIGFLAGS} $(foreach ext, ${EXT_PYAPI},-I${EXT_${ext}_PATH}/perlapi -I${EXT_${ext}_PATH}/capi -DECMD_$(shell echo ${ext} | tr "a-zA-Z" "A-Za-z")_EXTENSION_SUPPORT)
+CXXFLAGS  := ${CXXFLAGS} $(foreach ext, ${EXT_PYAPI},-I${EXT_${ext}_PATH}/capi -I${EXT_${ext}_PATH}/perlapi)
+SWIGFLAGS := ${SWIGFLAGS} $(foreach ext, ${EXT_PYAPI},-I${EXT_${ext}_PATH}/perlapi -I${EXT_${ext}_PATH}/capi)
 VPATH     := ${VPATH}$(foreach ext, ${EXT_PYAPI},:${EXT_${ext}_PATH}/capi:${EXT_${ext}_PATH}/perlapi)
 
 ### Setup all of the additional objects to link

--- a/ecmd-core/pyapi/makefile
+++ b/ecmd-core/pyapi/makefile
@@ -35,8 +35,8 @@ SOURCE    := ${SOURCE} $(foreach ext, ${EXT_PYAPI}, ${ext}ClientCapi.C ${ext}Cli
 # Remove the fapiClientCapi.C from the build, only will use fapiClientPyapi.C which has the init extension
 SOURCE    := $(subst fapi2ClientCapi.C,,${SOURCE})
 SOURCE    := $(subst fapiClientCapi.C,,${SOURCE})
-CXXFLAGS  := ${CXXFLAGS} $(foreach ext, ${EXT_PYAPI},-I${EXT_${ext}_PATH}/capi -I${EXT_${ext}_PATH}/pyapi -DECMD_$(shell echo ${ext} | tr "a-zA-Z" "A-Za-z")_EXTENSION_SUPPORT)
-SWIGFLAGS := ${SWIGFLAGS} $(foreach ext, ${EXT_PYAPI},-I${EXT_${ext}_PATH}/capi -I${EXT_${ext}_PATH}/pyapi -DECMD_$(shell echo ${ext} | tr "a-zA-Z" "A-Za-z")_EXTENSION_SUPPORT)
+CXXFLAGS  := ${CXXFLAGS} $(foreach ext, ${EXT_PYAPI},-I${EXT_${ext}_PATH}/capi -I${EXT_${ext}_PATH}/pyapi)
+SWIGFLAGS := ${SWIGFLAGS} $(foreach ext, ${EXT_PYAPI},-I${EXT_${ext}_PATH}/capi -I${EXT_${ext}_PATH}/pyapi)
 VPATH     := ${VPATH}$(foreach ext, ${EXT_PYAPI},:${EXT_${ext}_PATH}/capi:${EXT_${ext}_PATH}/pyapi)
 
 ### Setup all of the additional objects to link


### PR DESCRIPTION
Instead of it being generated in real time in the various makefiles,
moved it to one place in the config.py

This also allows for it to be controlled (i.e disabled)
by people using ecmdDefines.H

With it being defined in multiple places (header and commandline), it
was generating compiler redefinition warnings on every file compiled.

Signed-off-by: Jason Albert <albertj@us.ibm.com>