### PR TITLE
Default to using 64 bit versions in ecmdsetup

### DIFF
--- a/ecmd-core/bin/ecmdsetup.pl
+++ b/ecmd-core/bin/ecmdsetup.pl
@@ -81,7 +81,7 @@ my $release;
 my $prevRelease;
 my $plugin;
 my $product;
-my $bits = 32;
+my $bits = 64;
 my $arch;
 my $temp;
 my $shortcut = 0;


### PR DESCRIPTION
Signed-off-by: Kahn Evans <kahnevan@us.ibm.com>