### PR TITLE
Adding empty file for ecmd15 compatibility.  Allows it to be included…

### DIFF
--- a/ecmd-core/capi/makefile
+++ b/ecmd-core/capi/makefile
@@ -85,6 +85,9 @@ install:
 	cp ${OUTLIB}/${TARGET} ${INSTALL_PATH}/${TARGET_ARCH}/lib/.
 	cp ${CAPI_INCLUDES} ${INSTALL_PATH}/capi/.
 	cp ${SEDC_INCLUDES_INSTALL} ${INSTALL_PATH}/capi/.
+# Adding empty file for ecmd15 compatibility.  Allows it to be included from install path in either release.
+	@echo "Touching simClientCapi.H"
+	@touch ${INSTALL_PATH}/capi/simClientCapi.H
 	chmod 644 ${INSTALL_PATH}/capi/*
 	@echo "Installing eCMD Shared Lib to ${INSTALL_PATH}/${TARGET_ARCH}/lib/ ..."
 	cp ${OUTLIB}/${SLIB} ${INSTALL_PATH}/${TARGET_ARCH}/lib/.


### PR DESCRIPTION
… from install path in either release.

Signed-off-by: Kahn Evans <kahnevan@us.ibm.com>