### PR TITLE
Use python3 env

### DIFF
--- a/mkscripts/makeext.py
+++ b/mkscripts/makeext.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
We use ecmd-pdbg (https://github.com/open-power/ecmd-pdbg) in openbmc . recently openbmc infrastructure is completely moved to python3 and we are getting errors using just `python` env. so moving this to python3 env