### PR TITLE
Fix for finding latch array entries in hash file in full lookup mode

### DIFF
--- a/ecmd-core/dll/ecmdDllCapi.C
+++ b/ecmd-core/dll/ecmdDllCapi.C
@@ -5876,8 +5876,9 @@ uint32_t readScandefHash(ecmdChipTarget & target, const char* i_ringName, const 
     bool ringFound = false;
     bool foundLatch = false;
 
-    latchHashKey32 = ecmdHashString32(latchName.c_str(), 0);
-    latchHashKey64 = ecmdHashString64(latchName.c_str(), 0);
+    // Base hash key off of base latch name, particularly for array entries.  Remove array index.
+    latchHashKey32 = ecmdHashString32((latchName.substr(0,latchName.find_last_of("("))).c_str(), 0);
+    latchHashKey64 = ecmdHashString64((latchName.substr(0,latchName.find_last_of("("))).c_str(), 0);
 
     /* Transform to lower case for case-insensitive comparisons */
     transform(ringName.begin(), ringName.end(), ringName.begin(), (int(*)(int)) tolower);


### PR DESCRIPTION
Signed-off-by: Kahn Evans <kahnevan@us.ibm.com>

The full latch lookup mode uses the scandef hash file to speed up the search.  The hash keys are stored based on the base latch name, minus any latch bit information contained within parentheses.  This works fine currently for basic latches, but was not working correctly for arrays that look like this in the scandef:
ECP.EC.VS.STF02.BANKLD1.HRD.ARY.ARY0_71.RF_CELL.RFL2(13)(0:35)

The user would be passing in ECP.EC.VS.STF02.BANKLD1.HRD.ARY.ARY0_71.RF_CELL.RFL2(13) for the latch request.  Without this change, the full latch lookup would fail to find the hash key in the scandef hash file, and the user would have to use the much slower partial mode.  

This change just creates the hash key to search based on the base latch name instead.  The end result was reducing the lookup time from ~9 minutes to 12 seconds with this change.