### PR TITLE
pyecmd: Data buffer improvements

### DIFF
--- a/ecmd-core/pyecmd/__init__.py
+++ b/ecmd-core/pyecmd/__init__.py
@@ -129,7 +129,7 @@ class Target(_Target):
         if name in Target._attrs_with_state:
             if value == "*":
                 super(Target, self).__setattr__(name + "State", ecmd.ECMD_TARGET_FIELD_WILDCARD)
-            elif value == None:
+            elif value is None:
                 super(Target, self).__setattr__(name + "State", ecmd.ECMD_TARGET_FIELD_UNUSED)
             else:
                 super(Target, self).__setattr__(name, value)
@@ -151,6 +151,8 @@ class Target(_Target):
             for attr in Target._attrs_with_state:
                 self.__setattr__(attr, None)
         for (attr, value) in kwargs.items():
+            if attr not in self._attrs_with_state:
+                raise TypeError("unexpected keyword argument '%s'" % attr)
             setattr(self, attr, value)
 
     def __repr__(self):

--- a/ecmd-core/pyecmd/__init__.py
+++ b/ecmd-core/pyecmd/__init__.py
@@ -259,3 +259,15 @@ def saveDataBuffer(data, filename, save_format = ecmd.ECMD_SAVE_FORMAT_BINARY):
     """
     buf = _to_ecmdDataBuffer(data)
     _bufwrap(buf.writeFile(filename, save_format))
+
+def convertFromDataBuffer(buf):
+    """
+    Convert an ecmdDataBuffer (e.g. from a result list object) into an EcmdBitArray
+    """
+    return _from_ecmdDataBuffer(buf)
+
+def convertToDataBuffer(buf):
+    """
+    Convert a bit string into an ecmdDataBuffer
+    """
+    return _to_ecmdDataBuffer(buf)

--- a/ecmd-core/pyecmd/test_api.py
+++ b/ecmd-core/pyecmd/test_api.py
@@ -1,4 +1,5 @@
 from pyecmd import *
+from ecmd import ecmdDataBuffer
 
 extensions = {}
 if hasattr(ecmd, "fapi2InitExtension"):
@@ -27,3 +28,13 @@ with Ecmd(**extensions):
 
          t.fapi2SetAttr("ATTR_CHIP_ID", 42)
          assert(42 == t.fapi2GetAttr("ATTR_CHIP_ID"))
+
+     # Some buffer tests
+     b = ecmdDataBuffer(64)
+     b.setDoubleWord(0, 0x1234567812345678)
+     assert(convertFromDataBuffer(b).uint == 0x1234567812345678)
+
+     b = EcmdBitArray("0x1234567812345678")
+     assert(convertToDataBuffer(b).getDoubleWord(0) == 0x1234567812345678)
+     assert(convertToDataBuffer("0x1234567812345678").getDoubleWord(0) == 0x1234567812345678)
+     assert(convertToDataBuffer(0x1234567812345678).getDoubleWord(0) == 0x1234567812345678)


### PR DESCRIPTION
* Expose data buffer conversion as a public API
* Fix conversion from string to DataBuffer in Python 3
* Add conversion from byte strings
* Improve conversion performance big time by using the new
  ecmdDataBuffer.memCopy{In,Out} methods
* Add some unit tests for conversion