### PR TITLE
removing slibclean as it can't be executed on aix

### DIFF
--- a/ecmd-core/capi/ecmdClientCapi.C
+++ b/ecmd-core/capi/ecmdClientCapi.C
@@ -129,10 +129,6 @@ uint32_t ecmdLoadDll(std::string i_dllName) {
 #endif
 
 #ifndef ECMD_STATIC_FUNCTIONS
-#ifdef _AIX
-    /* clean up the machine from previous tests */
-  system("slibclean");
-#endif
 
     /* --------------------- */
     /* load DLL              */

--- a/ecmd-core/cmd/ecmdVersion.C
+++ b/ecmd-core/cmd/ecmdVersion.C
@@ -98,11 +98,6 @@ uint32_t ecmdCheckDllVersion(const char* options) {
     abort();
   }
 
-#ifdef _AIX
-  /* clean up the machine from previous tests */
-  system("slibclean");
-#endif
-
   /* --------------------- */
   /* load DLL              */
   /* --------------------- */


### PR DESCRIPTION
we are getting execute permissions denied on aix box, removing it as it is not needed