### PR TITLE
Add ability to specify the i2c flags that can be sent to the device d…

### DIFF
--- a/ecmd-core/capi/ecmdClientCapi.H
+++ b/ecmd-core/capi/ecmdClientCapi.H
@@ -5460,6 +5460,115 @@ uint32_t getSpyEnumImages(const ecmdChipTarget & i_target, const char * i_spyNam
 //@}
 #endif // ECMD_REMOVE_SPY_FUNCTIONS
 
+/** @name I2C Functions */
+//@{
+#ifndef ECMD_REMOVE_I2C_FUNCTIONS
+/**
+ @brief Read data from an I2C device
+ @param i_target Struct that specifies the target to operate on (see target depth and states below)
+ @param i_engineId I2c engine to use
+ @param i_port I2C port to use
+ @param i_slaveAddress I2C slave device address to use
+ @param i_busSpeed I2C Bus speed to use
+ @param i_bytes Byte length to read
+ @param o_data Data read from device
+ @param i_flags Bitmask of i2c flags
+ @retval ECMD_TARGET_NOT_CONFIGURED if target is not available in the system
+ @retval ECMD_TARGET_INVALID_TYPE if target doesn't support I2c
+ @retval ECMD_INVALID_ARGS Invalid argument values found
+ @retval ECMD_SUCCESS if successful
+ @retval non-zero if unsuccessful
+
+ TARGET DEPTH  : pos<br>
+ TARGET STATES : Unused <br>
+*/
+uint32_t ecmdI2cReadHidden(const ecmdChipTarget & i_target, uint32_t i_engineId, uint32_t i_port, uint32_t i_slaveAddress, ecmdI2cBusSpeed_t i_busSpeed , uint32_t i_bytes, ecmdDataBuffer & o_data, uint32_t i_flags);
+
+/**
+ @brief Read data from an I2C device at the given offset
+ @param i_target Struct that specifies the target to operate on (see target depth and states below)
+ @param i_engineId I2c engine to use
+ @param i_port I2C port to use
+ @param i_slaveAddress I2C slave device address to use
+ @param i_busSpeed I2C Bus speed to use
+ @param i_offset Byte offset in the device
+ @param i_offsetFieldSize Specifies the field size used in the I2C protocol of the slave device
+ @param i_bytes Byte length to read
+ @param o_data Data read from device
+ @param i_flags Bitmask of i2c flags
+ @retval ECMD_TARGET_NOT_CONFIGURED if target is not available in the system
+ @retval ECMD_TARGET_INVALID_TYPE if target doesn't support I2c
+ @retval ECMD_INVALID_ARGS Invalid argument values found
+ @retval ECMD_SUCCESS if successful
+ @retval non-zero if unsuccessful
+
+ TARGET DEPTH  : pos<br>
+ TARGET STATES : Unused <br>
+*/
+uint32_t ecmdI2cReadOffsetHidden2(const ecmdChipTarget & i_target, uint32_t i_engineId, uint32_t i_port, uint32_t i_slaveAddress, ecmdI2cBusSpeed_t i_busSpeed , uint64_t i_offset, uint32_t i_offsetFieldSize, uint32_t i_bytes, ecmdDataBuffer & o_data, uint32_t i_flags);
+
+/**
+ @brief Write the provided data into the I2C device
+ @param i_target Struct that specifies the target to operate on (see target depth and states below)
+ @param i_engineId I2c engine to use
+ @param i_port I2C port to use
+ @param i_slaveAddress I2C slave device address to use
+ @param i_busSpeed I2C Bus speed to use
+ @param i_data Data to write to device
+ @param i_flags Bitmask of i2c flags
+ @retval ECMD_TARGET_NOT_CONFIGURED if target is not available in the system
+ @retval ECMD_TARGET_INVALID_TYPE if target doesn't support I2c
+ @retval ECMD_INVALID_ARGS Invalid argument values found
+ @retval ECMD_SUCCESS if successful
+ @retval non-zero if unsuccessful
+
+ TARGET DEPTH  : pos<br>
+ TARGET STATES : Unused <br>
+*/
+uint32_t ecmdI2cWriteHidden(const ecmdChipTarget & i_target, uint32_t i_engineId, uint32_t i_port, uint32_t i_slaveAddress, ecmdI2cBusSpeed_t i_busSpeed , const ecmdDataBuffer & i_data, uint32_t i_flags);
+
+/**
+ @brief Write the provided data into the I2C device at the given offset
+ @param i_target Struct that specifies the target to operate on (see target depth and states below)
+ @param i_engineId I2c engine to use
+ @param i_port I2C port to use
+ @param i_slaveAddress I2C slave device address to use
+ @param i_busSpeed I2C Bus speed to use
+ @param i_offset Byte offset in the device
+ @param i_offsetFieldSize Specifies the field size used in the I2C protocol of the slave device
+ @param i_data Data to write to device
+ @param i_flags Bitmask of i2c flags
+ @retval ECMD_TARGET_NOT_CONFIGURED if target is not available in the system
+ @retval ECMD_TARGET_INVALID_TYPE if target doesn't support I2c
+ @retval ECMD_INVALID_ARGS Invalid argument values found
+ @retval ECMD_SUCCESS if successful
+ @retval non-zero if unsuccessful
+
+ TARGET DEPTH  : pos<br>
+ TARGET STATES : Unused <br>
+*/
+uint32_t ecmdI2cWriteOffsetHidden2(const ecmdChipTarget & i_target, uint32_t i_engineId, uint32_t i_port, uint32_t i_slaveAddress, ecmdI2cBusSpeed_t i_busSpeed , uint64_t i_offset, uint32_t i_offsetFieldSize, const ecmdDataBuffer & i_data, uint32_t i_flags);
+
+/**
+ @brief Let the user to run a series of command, while the i2c device is locked for the duration
+ @param i_target Struct that specifies the target to operate on (see target depth and states below)
+ @param io_cmdsEntries The series of commands to be run
+ @retval ECMD_TARGET_NOT_CONFIGURED if target is not available in the system
+ @retval ECMD_TARGET_INVALID_TYPE if target doesn't support I2c
+ @retval ECMD_INVALID_ARGS Invalid argument values found
+ @retval ECMD_SUCCESS if successful
+ @retval non-zero if unsuccessful
+
+ NOTE : The i2c device targeted is locked at the first use of the device in the list and then unlocked when the command is complete.<br>
+ NOTE : The output data on reads is filled into the ecmdDataBuffer in the list for that operation
+
+ TARGET DEPTH  : pos<br>
+ TARGET STATES : Unused <br>
+*/
+uint32_t ecmdI2CMultipleCmdsHidden(const ecmdChipTarget & i_target, std::list<ecmdI2CCmdEntryHidden> & io_cmdsEntries);
+#endif /* ifndef ECMD_REMOVE_I2C_FUNCTIONS (this comment has to be here for makedll.pl to work */
+//@}
+
 #ifndef DOCUMENTATION
 }  //extern "C"
 #endif

--- a/ecmd-core/capi/ecmdStructs.C
+++ b/ecmd-core/capi/ecmdStructs.C
@@ -5268,6 +5268,307 @@ void  ecmdI2CCmdEntry::printStruct() const
 #endif  // end of ECMD_STRIP_DEBUG
 // @07 end
 
+// @07.5 start
+/*
+ * The following methods for the ecmdI2CCmdEntryHidden struct will flatten,
+ * unflatten & get the flattened size of the struct.
+ */
+uint32_t ecmdI2CCmdEntryHidden::flatten(uint8_t *o_buf, uint32_t i_len)
+{
+        uint32_t tmpData32 = 0;
+        uint32_t l_rc = ECMD_SUCCESS;
+
+        uint32_t dataBufSize = 0; // holder for ecmdDataBuffer size
+        int l_len = (int)i_len;   // use a local copy to decrement
+	uint8_t *l_ptr8 = o_buf;  // pointer to the output buffer
+
+        do      // Single entry ->
+        {
+            // Check for buffer overflow conditions.
+            if (this->flattenSize() > i_len) 
+            {
+                // Generate an error for buffer overflow conditions.
+                ETRAC2("ECMD: Buffer overflow occurred in "
+                       "ecmdI2CCmdEntryHidden::flatten(), "
+                       "structure size = %d; input length = %d",
+                       this->flattenSize(), i_len);
+                l_rc = ECMD_DATA_OVERFLOW;
+                break;
+            }
+
+            // Flatten and store each data member in the ouput buffer
+
+            // "ecmdI2CCmd" (ecmdI2CCmds_t, stored as uint32_t)
+	    tmpData32 = htonl( (uint32_t)ecmdI2CCmd );
+	    memcpy( l_ptr8, &tmpData32, sizeof(tmpData32) );
+	    l_ptr8 += sizeof(tmpData32);
+	    l_len -= sizeof(tmpData32);
+
+            // "engineId" (uint32_t)
+            tmpData32 = htonl( engineId );
+            memcpy( l_ptr8, &tmpData32, sizeof(tmpData32) );
+            l_ptr8 += sizeof(engineId);
+            l_len -= sizeof(engineId);
+
+            // "port" (uint32_t)
+            tmpData32 = htonl( port );
+            memcpy( l_ptr8, &tmpData32, sizeof(tmpData32) );
+            l_ptr8 += sizeof(port);
+            l_len -= sizeof(port);
+
+            // "slaveaddress" (uint32_t)
+            tmpData32 = htonl( slaveaddress );
+            memcpy( l_ptr8, &tmpData32, sizeof(tmpData32) );
+            l_ptr8 += sizeof(slaveaddress);
+            l_len -= sizeof(slaveaddress);
+
+            // "busSpeed" (ecmdI2cBusSpeed_t, stored as uint32_t)
+	    tmpData32 = htonl( (uint32_t)busSpeed );
+	    memcpy( l_ptr8, &tmpData32, sizeof(tmpData32) );
+	    l_ptr8 += sizeof(tmpData32);
+	    l_len -= sizeof(tmpData32);
+
+            // "byteOffset" (uint32_t)
+            tmpData32 = htonl( byteOffset );
+            memcpy( l_ptr8, &tmpData32, sizeof(tmpData32) );
+            l_ptr8 += sizeof(byteOffset);
+            l_len -= sizeof(byteOffset);
+
+            // "offsetFieldSize" (uint32_t)
+            tmpData32 = htonl( offsetFieldSize );
+            memcpy( l_ptr8, &tmpData32, sizeof(tmpData32) );
+            l_ptr8 += sizeof(offsetFieldSize);
+            l_len -= sizeof(offsetFieldSize);
+
+            // "readByteLength" (uint32_t)
+            tmpData32 = htonl( readByteLength );
+            memcpy( l_ptr8, &tmpData32, sizeof(tmpData32) );
+            l_ptr8 += sizeof(readByteLength);
+            l_len -= sizeof(readByteLength);
+
+            // "data" (ecmdDataBuffer)
+            //  1st save the size of the buffer
+            dataBufSize = data.flattenSize();
+            tmpData32 = htonl( dataBufSize );
+            memcpy( l_ptr8, &tmpData32, sizeof(tmpData32) );
+            l_ptr8 += sizeof( dataBufSize );
+            l_len -= sizeof( dataBufSize );
+
+            //  2nd, flatten and save the buffer
+            l_rc = data.flatten( l_ptr8, dataBufSize );
+
+            // If the flatten failed, exit now with an error
+            if ( l_rc != ECMD_DBUF_SUCCESS )
+            {
+               break;  // exit the do loop
+            } 
+            else
+            {
+               l_rc = ECMD_SUCCESS;  // restore standard success value
+            }
+            l_ptr8 += dataBufSize;
+            l_len -= dataBufSize;
+
+            // "i2cFlags" (uint32_t)
+            tmpData32 = htonl( i2cFlags );
+            memcpy( l_ptr8, &tmpData32, sizeof(tmpData32) );
+            l_ptr8 += sizeof(i2cFlags);
+            l_len -= sizeof(i2cFlags);
+
+            // Final check: if the length isn't 0, something went wrong
+            if (l_len < 0)
+            {	
+               // Generate an error for buffer overflow conditions.
+               ETRAC3("ECMD: Buffer overflow occurred in "
+                      "ecmdI2CCmdEntryHidden::flatten(), struct size= %d; "
+                      "input length= %d; remainder= %d\n",
+                      this->flattenSize(), i_len, l_len);
+               l_rc = ECMD_DATA_OVERFLOW;
+               break;
+            }
+
+            if (l_len > 0)
+            {	
+               // Generate an error for buffer underflow conditions.
+               ETRAC3("ECMD: Buffer underflow occurred in "
+                      "ecmdI2CCmdEntryHidden::flatten() struct size= %d; "
+                      "input length= %d; remainder= %d\n",
+                      this->flattenSize(), i_len, l_len);
+               l_rc = ECMD_DATA_UNDERFLOW;
+               break;
+            }
+
+        } while (false);   // <- single exit
+
+        return l_rc;
+}
+
+
+uint32_t ecmdI2CCmdEntryHidden::unflatten(const uint8_t *i_buf, uint32_t i_len)
+{
+        uint32_t l_rc = ECMD_SUCCESS;
+        uint32_t tmpData32 = 0;
+
+        uint32_t dataBufSize = 0;       // holds size of data buffer
+	int l_len = (int)i_len;         // use a local copy to decrement
+        const uint8_t *l_ptr8 = i_buf;  // pointer to the input buffer
+
+        do    // Single entry ->
+        {
+            // Unflatten each data member from the input buffer
+
+            // "ecmdI2CCmd" (ecmdI2CCmds_t, stored as uint32_t)
+	    memcpy( &tmpData32, l_ptr8, sizeof(tmpData32) );
+            ecmdI2CCmd = (ecmdI2CCmds_t)ntohl( tmpData32 );
+	    l_ptr8 += sizeof(tmpData32);
+	    l_len -= sizeof(tmpData32);
+
+            // "engineId" (uint32_t)
+            memcpy( &engineId, l_ptr8, sizeof(engineId) );
+            engineId = ntohl( engineId );
+            l_ptr8 += sizeof(engineId);
+            l_len -= sizeof(engineId);
+
+            // "port" (uint32_t)
+            memcpy( &port, l_ptr8, sizeof(port) );
+            port = ntohl( port );
+            l_ptr8 += sizeof(port);
+            l_len -= sizeof(port);
+
+            // "slaveaddress" (uint32_t)
+            memcpy( &slaveaddress, l_ptr8, sizeof(slaveaddress) );
+            slaveaddress = ntohl( slaveaddress );
+            l_ptr8 += sizeof(slaveaddress);
+            l_len -= sizeof(slaveaddress);
+
+            // "busSpeed" (ecmdI2cBusSpeed_t, stored as uint32_t)
+	    memcpy( &tmpData32, l_ptr8, sizeof(tmpData32) );
+            busSpeed = (ecmdI2cBusSpeed_t)ntohl( tmpData32 );
+	    l_ptr8 += sizeof(tmpData32);
+	    l_len -= sizeof(tmpData32);
+
+            // "byteOffset" (uint32_t)
+            memcpy( &byteOffset, l_ptr8, sizeof(byteOffset) );
+            byteOffset = ntohl( byteOffset );
+            l_ptr8 += sizeof(byteOffset);
+            l_len -= sizeof(byteOffset);
+
+            // "offsetFieldSize" (uint32_t)
+            memcpy( &offsetFieldSize, l_ptr8, sizeof(offsetFieldSize) );
+            offsetFieldSize = ntohl( offsetFieldSize );
+            l_ptr8 += sizeof(offsetFieldSize);
+            l_len -= sizeof(offsetFieldSize);
+
+            // "readByteLength" (uint32_t)
+            memcpy( &readByteLength, l_ptr8, sizeof(readByteLength) );
+            readByteLength = ntohl( readByteLength );
+            l_ptr8 += sizeof(readByteLength);
+            l_len -= sizeof(readByteLength);
+
+            // "data" (ecmdDataBuffer)
+            //  1st get the size of the data buffer
+            memcpy( &dataBufSize, l_ptr8, sizeof(dataBufSize) );
+            dataBufSize = ntohl( dataBufSize );
+            l_ptr8 += sizeof( dataBufSize );
+            l_len -= sizeof( dataBufSize );
+
+            //  2nd, unflatten the data buffer "data"
+            l_rc = data.unflatten( l_ptr8, dataBufSize );
+
+            // If the unflatten failed, exit now with an error
+            if ( l_rc != ECMD_DBUF_SUCCESS )
+            {
+               break;
+            }
+            else
+            {
+               l_rc = ECMD_SUCCESS;  // restore standard success value
+            }
+            l_ptr8 += dataBufSize;
+            l_len -= dataBufSize;
+
+            // "i2cFlags" (uint32_t)
+            memcpy( &i2cFlags, l_ptr8, sizeof(i2cFlags) );
+            i2cFlags = ntohl( i2cFlags );
+            l_ptr8 += sizeof(i2cFlags);
+            l_len -= sizeof(i2cFlags);
+
+            // Final check: if the length isn't 0, something went wrong
+            if (l_len < 0)
+            {	
+               // Generate an error for buffer overflow conditions.
+               ETRAC3("ECMD: Buffer overflow occurred in "
+                      "ecmdI2CCmdEntryHidden::unflatten(), struct size= %d; "
+                      "input length= %d; remainder= %d\n",
+                      this->flattenSize(), i_len, l_len);
+               l_rc = ECMD_DATA_OVERFLOW;
+               break;
+            }
+
+            if (l_len > 0)
+            {	
+               // Generate an error for buffer underflow conditions.
+               ETRAC3("ECMD: Buffer underflow occurred in "
+                      "ecmdI2CCmdEntryHidden::unflatten() struct size= %d; "
+                      "input length= %d; remainder= %d\n",
+                      this->flattenSize(), i_len, l_len);
+               l_rc = ECMD_DATA_UNDERFLOW;
+               break;
+            }
+
+        } while (false);   // <- single exit
+
+        return l_rc;
+}
+
+
+uint32_t ecmdI2CCmdEntryHidden::flattenSize() const
+{
+        uint32_t flatSize = 0;
+
+        // Calculate the size needed to store the flattened struct
+        flatSize = sizeof(uint32_t)  // ecmdI2CCmd stored as uint32_t
+                   + sizeof(engineId)
+                   + sizeof(port)
+                   + sizeof(slaveaddress)
+                   + sizeof(uint32_t)  // busSpeed stored as uint32_t
+                   + sizeof(byteOffset)
+                   + sizeof(offsetFieldSize)
+                   + sizeof(readByteLength)
+                   + sizeof(uint32_t)  // size of "data" stored in uint32_t
+                   + data.flattenSize()
+                   + sizeof(i2cFlags);
+
+        return flatSize;
+}
+
+
+#ifndef ECMD_STRIP_DEBUG
+void  ecmdI2CCmdEntryHidden::printStruct() const
+{
+        uint32_t bufSize = 0;
+        std::string bufString;
+
+        printf("\n\t--- I2C CMD Entry Structure ---\n");
+
+        printf("\tI2C Command: 0x%x\n", (uint32_t)ecmdI2CCmd);
+        printf("\tEngine ID: 0x%08x\n", engineId);
+        printf("\tPort: 0x%08x\n", port);
+        printf("\tSlave Address: 0x%08x\n", slaveaddress);
+        printf("\tBus Speed: 0x%x\n", (uint32_t)busSpeed);
+        printf("\tOffset: 0x%08x\n", byteOffset);
+        printf("\tOffset Field Size: 0x%08x\n", offsetFieldSize);
+        printf("\tByte: 0x%08x\n", readByteLength);
+
+        bufSize = data.getBitLength();
+        bufString = data.genHexLeftStr(0, bufSize);
+        printf("\tData: bit length = %d\n", bufSize);
+        printf("\tData: contents = %s\n", bufString.c_str() );
+
+        printf("\tI2CFlags: 0x%08x\n", i2cFlags);
+}
+#endif  // end of ECMD_STRIP_DEBUG
+// @07 end
 
 /*
  * The following methods for the ecmdNameEntry struct will flatten, unflatten &

--- a/ecmd-core/capi/ecmdStructs.H
+++ b/ecmd-core/capi/ecmdStructs.H
@@ -388,6 +388,12 @@ typedef enum {
 } ecmdI2cBusSpeed_t;
 
 /**
+ @brief Used by I2C functions to specify the contents of the eCMD i2c flags parameter
+*/
+#define ECMD_I2C_FLAGS_I2C_SLAVE_FORCE         0x00000001
+
+
+/**
  @brief Used by ecmdGpioWriteConfigRegister to specify the type of operation to do
 */
 typedef enum {
@@ -2242,6 +2248,60 @@ readByteLength(0)                            //fix beam error
 // ecmdI2CCmdEntry Destructor
 inline ecmdI2CCmdEntry::~ecmdI2CCmdEntry() { }
 #endif
+
+/**
+ @brief Used by ecmdI2CMultipleCmdsHidden API
+*/
+struct ecmdI2CCmdEntryHidden {
+
+#ifndef DOCUMENTATION
+  // Constructor
+  ecmdI2CCmdEntryHidden();
+
+  // Destructor
+  ~ecmdI2CCmdEntryHidden();
+
+  // Methods
+  uint32_t flatten(uint8_t *o_buf, uint32_t i_len);
+  uint32_t unflatten(const uint8_t *i_buf, uint32_t i_len);
+  uint32_t flattenSize(void) const;
+#ifndef ECMD_STRIP_DEBUG
+  void printStruct(void) const;
+#endif
+#endif
+
+  // Members
+  ecmdI2CCmds_t ecmdI2CCmd;     ///< The eCMD API to target with this command
+  uint32_t engineId;            ///< The i2c engine to use
+  uint32_t port;                ///< The i2c port to use
+  uint32_t slaveaddress;        ///< The i2c slave device address to use
+  ecmdI2cBusSpeed_t busSpeed;   ///< The i2c bus speed to use
+  uint32_t byteOffset;          ///< Byte offset in the device (needed for offset commands only)
+  uint32_t offsetFieldSize;     ///< Specifies the field size used in the i2c protocal of the slave device (needed for offset commands only)
+  uint32_t readByteLength;      ///< Byte length to read (only needed on reads)
+  ecmdDataBuffer data;          ///< The data returned from the i2c operation
+  uint32_t i2cFlags;            ///< The i2c flags to use
+};
+
+#ifndef DOCUMENTATION
+// ecmdI2CCmdEntry Constructor
+inline ecmdI2CCmdEntryHidden::ecmdI2CCmdEntryHidden():
+ecmdI2CCmd(ECMD_I2C_UNKNOWN),                //fix beam error
+engineId(0),
+port(0),
+slaveaddress(0),
+busSpeed(ECMD_I2C_BUSSPEED_UNKNOWN),         //fix beam error
+byteOffset(0),
+offsetFieldSize(0),
+readByteLength(0),                           //fix beam error
+i2cFlags(0)
+{
+}
+
+// ecmdI2CCmdEntry Destructor
+inline ecmdI2CCmdEntryHidden::~ecmdI2CCmdEntryHidden() { }
+#endif
+
 
 /**
  @brief Used by simGetModelInfo

--- a/ecmd-core/cmd/help/geti2c.htxt
+++ b/ecmd-core/cmd/help/geti2c.htxt
@@ -1,9 +1,9 @@
 
 Syntax: 
         WITHOUT OFFSET:
-        geti2c <Chip> <EngineId> <Port> <SlaveAddress> <Bytes> [-o<format> | -f<filename>] [-busspeed <speed>]
+        geti2c <Chip> <EngineId> <Port> <SlaveAddress> <Bytes> [-o<format> | -f<filename>] [-busspeed <speed>] [-i2cflags <flags>]
         WITH OFFSET:
-        geti2c <Chip> <EngineId> <Port> <SlaveAddress> <Bytes> <Offset> <FieldSize> [-o<format> | -f<filename>] [-busspeed <speed>]
+        geti2c <Chip> <EngineId> <Port> <SlaveAddress> <Bytes> <Offset> <FieldSize> [-o<format> | -f<filename>] [-busspeed <speed>] [-i2cflags <flags>]
         [-quiet] [-quieterror] [-exist] [-coe] [-a#] [-k#] [-n#] [-s#] [-p#]
 
         ECMD:           Core Common Function
@@ -31,8 +31,10 @@ Syntax:
 
         FieldSize       Byte width of the offset
 
-        -busspeed [opt] Specifies the bus speed to run i2c in khz : default 400
-                        Valid values are 400, 100, 50
+        -busspeed [opt] Specifies the bus speed to run i2c in khz : default set by plugin
+                        Valid values are 1000, 400, 100, 50
+
+        -i2cflags       Specifies the i2c flags to be passed in to the plugin
 
         -o<format>[opt] Specifies the format type of the output : default 'xl'
                         Run 'ecmdquery formats' to view available formats

--- a/ecmd-core/cmd/help/puti2c.htxt
+++ b/ecmd-core/cmd/help/puti2c.htxt
@@ -2,13 +2,13 @@
 Syntax: 
         WITHOUT OFFSET:
         puti2c <Chip> <EngineId> <Port> <SlaveAddress> <Data>
-                         [-coe] [-a#] [-k#] [-n#] [-s#] [-p#] [-i<format>] [-busspeed <speed>]
+                         [-coe] [-a#] [-k#] [-n#] [-s#] [-p#] [-i<format>] [-busspeed <speed>] [-i2cflags <flags>]
         puti2c <Chip> <EngineId> <Port> <SlaveAddress> -f<filename>
-                         [-coe] [-a#] [-k#] [-n#] [-s#] [-p#] [-busspeed <speed>]
+                         [-coe] [-a#] [-k#] [-n#] [-s#] [-p#] [-busspeed <speed>] [-i2cflags <flags>]
 
         WITH OFFSET:
-        puti2c <Chip> <EngineId> <Port> <SlaveAddress> <Data> <Offset> <FieldSize> [-i<format>] [-busspeed <speed>]
-        puti2c <Chip> <EngineId> <Port> <SlaveAddress> -f<filename> <Offset> <FieldSize> [-busspeed <speed>]
+        puti2c <Chip> <EngineId> <Port> <SlaveAddress> <Data> <Offset> <FieldSize> [-i<format>] [-busspeed <speed>] [-i2cflags <flags>]
+        puti2c <Chip> <EngineId> <Port> <SlaveAddress> -f<filename> <Offset> <FieldSize> [-busspeed <speed>] [-i2cflags <flags>]
         [-quiet] [-quieterror] [-exist] [-coe] [-a#] [-k#] [-n#] [-s#] [-p#]
 
         ECMD:           Core Common Function
@@ -35,8 +35,10 @@ Syntax:
 
         FieldSize       Byte width of the offset
 
-        -busspeed [opt] Specifies the bus speed to run i2c in khz : default 400
-                        Valid values are 400, 100, 50
+        -busspeed [opt] Specifies the bus speed to run i2c in khz : default set by plugin
+                        Valid values are 1000, 400, 100, 50
+
+        -i2cflags       Specifies the i2c flags to be passed in to the plugin
 
         -i<format>[opt] Specifies the format type of the input : default 'xl'
                         Run 'ecmdquery formats' to view available formats

--- a/ecmd-core/perlapi/ecmdClientPerlapi.i
+++ b/ecmd-core/perlapi/ecmdClientPerlapi.i
@@ -80,6 +80,7 @@
 %template(listEcmdScomDataHidden)    std::list<ecmdScomDataHidden>;
 %template(listEcmdFileLocation)      std::list<ecmdFileLocation>;
 %template(listEcmdI2CCmdEntry)       std::list<ecmdI2CCmdEntry>;
+%template(listEcmdI2CCmdEntryHidden) std::list<ecmdI2CCmdEntryHidden>;
 %template(listEcmdConnectionData)    std::list<ecmdConnectionData>;
 %template(listEcmdScomEntry)         std::list<ecmdScomEntry>;
 %template(listUint32_t)              std::list<uint32_t>;
@@ -117,6 +118,7 @@
 %copyctor ecmdCacheData;
 %copyctor ecmdSpyData;
 %copyctor ecmdI2CCmdEntry;
+%copyctor ecmdI2CCmdEntryHidden;
 %copyctor ecmdSimModelInfo;
 %copyctor ecmdConnectionData;
 %copyctor ecmdPnorListEntryData;

--- a/ecmd-core/perlapi/ecmdPerlApiTypes.H
+++ b/ecmd-core/perlapi/ecmdPerlApiTypes.H
@@ -244,6 +244,11 @@ typedef ecmdChipTargetList ecmdChipTargetList;
 */
 typedef ecmdI2CCmdEntryList ecmdI2CCmdEntryList;
 /**
+ @brief The perl version of the ecmdI2CCmdEntryHidden C API std::list
+ @see List
+*/
+typedef ecmdI2CCmdEntryHiddenList ecmdI2CCmdEntryHiddenList;
+/**
  @brief The perl version of the ecmdDataBuffer Vector
  @see Vector
 */

--- a/ecmd-core/pyapi/ecmdClientPyapi.i
+++ b/ecmd-core/pyapi/ecmdClientPyapi.i
@@ -77,6 +77,7 @@
 %template(ecmdScomDataList)          std::list<ecmdScomData>;
 %template(ecmdScomDataHiddenList)    std::list<ecmdScomDataHidden>;
 %template(ecmdI2CCmdEntryList)       std::list<ecmdI2CCmdEntry>;
+%template(ecmdI2CCmdEntryHiddenList) std::list<ecmdI2CCmdEntryHidden>;
 %template(ecmdConnectionDataList)    std::list<ecmdConnectionData>;
 %template(ecmdScomEntryList)         std::list<ecmdScomEntry>;
 %template(ecmdFileLocationList)      std::list<ecmdFileLocation>;
@@ -281,6 +282,13 @@ def __deepcopy__(self, memo):
 %pythoncode %{
 def __deepcopy__(self, memo):
     return ecmdI2CCmdEntry(self)
+%}
+}
+%copyctor ecmdI2CCmdEntryHidden;
+%extend ecmdI2CCmdEntryHidden {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return ecmdI2CCmdEntryHidden(self)
 %}
 }
 %copyctor ecmdSimModelInfo;

--- a/ecmd-core/pyapi/ecmdPyApiTypes.H
+++ b/ecmd-core/pyapi/ecmdPyApiTypes.H
@@ -246,6 +246,11 @@ typedef ecmdScomDataHiddenList ecmdScomDataHiddenList;
 */
 typedef ecmdI2CCmdEntryList ecmdI2CCmdEntryList;
 /**
+ @brief The python version of the ecmdI2CCmdEntryHidden C API std::list
+ @see List
+*/
+typedef ecmdI2CCmdEntryHiddenList ecmdI2CCmdEntryHiddenList;
+/**
  @brief The python version of the ecmdConnectionData C API std::list
  @see List
 */

--- a/ecmd-core/pyapi/makefile
+++ b/ecmd-core/pyapi/makefile
@@ -87,7 +87,7 @@ pyapi_install:
 
 test:
 	@echo "***** If you see python load errors this build of the python module is invalid ****"
-	@ECMD_DLL_FILE=${OUTLIB}/stub.dll PYTHONPATH=${OUTPY} LD_LIBRARY_PATH=${OUTLIB}:${OUTPY} ${ECMDPYTHONBIN} ../pyapi/testBuild.py
+	${VERBOSE}ECMD_DLL_FILE=${OUTLIB}/stub.dll PYTHONPATH=${OUTPY} LD_LIBRARY_PATH=${OUTLIB}:${OUTPY} ${ECMDPYTHONBIN} ../pyapi/testBuild.py
 
 doxygen-pyapi:
 	@cp ecmdPyApiTypes.H ${DOXYGEN_PERLAPI_PATH}/.


### PR DESCRIPTION
…river or plugin.

Change default busspeed to unknown so plugin can set appropriate default.  Affects cases where we need to know something was specified on the command line vs just being set.

Signed-off-by: Steven Janssen <janssens@us.ibm.com>