### PR TITLE
Add ability to specify the i2c flags that can be sent to the device d…

### DIFF
--- a/ecmd-core/capi/ecmdClientCapi.H
+++ b/ecmd-core/capi/ecmdClientCapi.H
@@ -3292,6 +3292,7 @@ uint32_t ecmdI2cReset(const ecmdChipTarget & i_target, uint32_t i_engineId, uint
  @param i_busSpeed I2C Bus speed to use
  @param i_bytes Byte length to read
  @param o_data Data read from device
+ @param i_flags Bitmask of i2c flags
  @retval ECMD_TARGET_NOT_CONFIGURED if target is not available in the system
  @retval ECMD_TARGET_INVALID_TYPE if target doesn't support I2c
  @retval ECMD_INVALID_ARGS Invalid argument values found
@@ -3301,7 +3302,7 @@ uint32_t ecmdI2cReset(const ecmdChipTarget & i_target, uint32_t i_engineId, uint
  TARGET DEPTH  : pos<br>
  TARGET STATES : Unused <br>
 */
-uint32_t ecmdI2cRead(const ecmdChipTarget & i_target, uint32_t i_engineId, uint32_t i_port, uint32_t i_slaveAddress, ecmdI2cBusSpeed_t i_busSpeed , uint32_t i_bytes, ecmdDataBuffer & o_data);
+uint32_t ecmdI2cRead(const ecmdChipTarget & i_target, uint32_t i_engineId, uint32_t i_port, uint32_t i_slaveAddress, ecmdI2cBusSpeed_t i_busSpeed , uint32_t i_bytes, ecmdDataBuffer & o_data, uint32_t i_flags);
 
 /**
  @brief Read data from an I2C device at the given offset
@@ -3314,6 +3315,7 @@ uint32_t ecmdI2cRead(const ecmdChipTarget & i_target, uint32_t i_engineId, uint3
  @param i_offsetFieldSize Specifies the field size used in the I2C protocol of the slave device
  @param i_bytes Byte length to read
  @param o_data Data read from device
+ @param i_flags Bitmask of i2c flags
  @retval ECMD_TARGET_NOT_CONFIGURED if target is not available in the system
  @retval ECMD_TARGET_INVALID_TYPE if target doesn't support I2c
  @retval ECMD_INVALID_ARGS Invalid argument values found
@@ -3323,7 +3325,7 @@ uint32_t ecmdI2cRead(const ecmdChipTarget & i_target, uint32_t i_engineId, uint3
  TARGET DEPTH  : pos<br>
  TARGET STATES : Unused <br>
 */
-uint32_t ecmdI2cReadOffset(const ecmdChipTarget & i_target, uint32_t i_engineId, uint32_t i_port, uint32_t i_slaveAddress, ecmdI2cBusSpeed_t i_busSpeed , uint64_t i_offset, uint32_t i_offsetFieldSize, uint32_t i_bytes, ecmdDataBuffer & o_data);
+uint32_t ecmdI2cReadOffset(const ecmdChipTarget & i_target, uint32_t i_engineId, uint32_t i_port, uint32_t i_slaveAddress, ecmdI2cBusSpeed_t i_busSpeed , uint64_t i_offset, uint32_t i_offsetFieldSize, uint32_t i_bytes, ecmdDataBuffer & o_data, uint32_t i_flags);
 
 /**
  @brief Write the provided data into the I2C device
@@ -3333,6 +3335,7 @@ uint32_t ecmdI2cReadOffset(const ecmdChipTarget & i_target, uint32_t i_engineId,
  @param i_slaveAddress I2C slave device address to use
  @param i_busSpeed I2C Bus speed to use
  @param i_data Data to write to device
+ @param i_flags Bitmask of i2c flags
  @retval ECMD_TARGET_NOT_CONFIGURED if target is not available in the system
  @retval ECMD_TARGET_INVALID_TYPE if target doesn't support I2c
  @retval ECMD_INVALID_ARGS Invalid argument values found
@@ -3342,7 +3345,7 @@ uint32_t ecmdI2cReadOffset(const ecmdChipTarget & i_target, uint32_t i_engineId,
  TARGET DEPTH  : pos<br>
  TARGET STATES : Unused <br>
 */
-uint32_t ecmdI2cWrite(const ecmdChipTarget & i_target, uint32_t i_engineId, uint32_t i_port, uint32_t i_slaveAddress, ecmdI2cBusSpeed_t i_busSpeed , const ecmdDataBuffer & i_data);
+uint32_t ecmdI2cWrite(const ecmdChipTarget & i_target, uint32_t i_engineId, uint32_t i_port, uint32_t i_slaveAddress, ecmdI2cBusSpeed_t i_busSpeed , const ecmdDataBuffer & i_data, uint32_t i_flags);
 
 /**
  @brief Write the provided data into the I2C device at the given offset
@@ -3354,6 +3357,7 @@ uint32_t ecmdI2cWrite(const ecmdChipTarget & i_target, uint32_t i_engineId, uint
  @param i_offset Byte offset in the device
  @param i_offsetFieldSize Specifies the field size used in the I2C protocol of the slave device
  @param i_data Data to write to device
+ @param i_flags Bitmask of i2c flags
  @retval ECMD_TARGET_NOT_CONFIGURED if target is not available in the system
  @retval ECMD_TARGET_INVALID_TYPE if target doesn't support I2c
  @retval ECMD_INVALID_ARGS Invalid argument values found
@@ -3363,7 +3367,7 @@ uint32_t ecmdI2cWrite(const ecmdChipTarget & i_target, uint32_t i_engineId, uint
  TARGET DEPTH  : pos<br>
  TARGET STATES : Unused <br>
 */
-uint32_t ecmdI2cWriteOffset(const ecmdChipTarget & i_target, uint32_t i_engineId, uint32_t i_port, uint32_t i_slaveAddress, ecmdI2cBusSpeed_t i_busSpeed , uint64_t i_offset, uint32_t i_offsetFieldSize, const ecmdDataBuffer & i_data);
+uint32_t ecmdI2cWriteOffset(const ecmdChipTarget & i_target, uint32_t i_engineId, uint32_t i_port, uint32_t i_slaveAddress, ecmdI2cBusSpeed_t i_busSpeed , uint64_t i_offset, uint32_t i_offsetFieldSize, const ecmdDataBuffer & i_data, uint32_t i_flags);
 
 /**
  @brief Let the user to run a series of command, while the i2c device is locked for the duration

--- a/ecmd-core/capi/ecmdStructs.C
+++ b/ecmd-core/capi/ecmdStructs.C
@@ -5074,6 +5074,12 @@ uint32_t ecmdI2CCmdEntry::flatten(uint8_t *o_buf, uint32_t i_len) const
             l_ptr8 += dataBufSize;
             l_len -= dataBufSize;
 
+            // "i2cFlags" (uint32_t)
+            tmpData32 = htonl( i2cFlags );
+            memcpy( l_ptr8, &tmpData32, sizeof(tmpData32) );
+            l_ptr8 += sizeof(i2cFlags);
+            l_len -= sizeof(i2cFlags);
+
             // Final check: if the length isn't 0, something went wrong
             if (l_len < 0)
             {	
@@ -5186,6 +5192,12 @@ uint32_t ecmdI2CCmdEntry::unflatten(const uint8_t *i_buf, uint32_t i_len)
             l_ptr8 += dataBufSize;
             l_len -= dataBufSize;
 
+            // "i2cFlags" (uint32_t)
+            memcpy( &i2cFlags, l_ptr8, sizeof(i2cFlags) );
+            i2cFlags = ntohl( i2cFlags );
+            l_ptr8 += sizeof(i2cFlags);
+            l_len -= sizeof(i2cFlags);
+
             // Final check: if the length isn't 0, something went wrong
             if (l_len < 0)
             {	
@@ -5229,7 +5241,8 @@ uint32_t ecmdI2CCmdEntry::flattenSize() const
                    + sizeof(offsetFieldSize)
                    + sizeof(readByteLength)
                    + sizeof(uint32_t)  // size of "data" stored in uint32_t
-                   + data.flattenSize();
+                   + data.flattenSize()
+                   + sizeof(i2cFlags);
 
         return flatSize;
 }
@@ -5257,10 +5270,10 @@ void  ecmdI2CCmdEntry::printStruct() const
         printf("\tData: bit length = %d\n", bufSize);
         printf("\tData: contents = %s\n", bufString.c_str() );
 
+        printf("\tI2CFlags: 0x%08x\n", i2cFlags);
 }
 #endif  // end of ECMD_STRIP_DEBUG
 // @07 end
-
 
 /*
  * The following methods for the ecmdNameEntry struct will flatten, unflatten &

--- a/ecmd-core/capi/ecmdStructs.H
+++ b/ecmd-core/capi/ecmdStructs.H
@@ -323,6 +323,12 @@ typedef enum {
 } ecmdI2cBusSpeed_t;
 
 /**
+ @brief Used by I2C functions to specify the contents of the eCMD i2c flags parameter
+*/
+#define ECMD_I2C_FLAGS_I2C_SLAVE_FORCE         0x00000001
+
+
+/**
  @brief Used by ecmdGpioWriteConfigRegister to specify the type of operation to do
 */
 typedef enum {
@@ -1949,6 +1955,7 @@ struct ecmdI2CCmdEntry {
   uint32_t offsetFieldSize;     ///< Specifies the field size used in the i2c protocal of the slave device (needed for offset commands only)
   uint32_t readByteLength;      ///< Byte length to read (only needed on reads)
   ecmdDataBuffer data;          ///< The data returned from the i2c operation
+  uint32_t i2cFlags;            ///< The i2c flags to use
 };
 
 #ifndef DOCUMENTATION
@@ -1961,7 +1968,8 @@ slaveaddress(0),
 busSpeed(ECMD_I2C_BUSSPEED_UNKNOWN),         //fix beam error
 byteOffset(0),
 offsetFieldSize(0),
-readByteLength(0)                            //fix beam error
+readByteLength(0),                           //fix beam error
+i2cFlags(0)
 {
 }
 

--- a/ecmd-core/cmd/ecmdI2cGpioUser.C
+++ b/ecmd-core/cmd/ecmdI2cGpioUser.C
@@ -74,7 +74,8 @@ uint32_t ecmdGetI2cUser(int argc, char * argv[]) {
   ecmdLooperData looperdata1;           ///< looper to do the real work
   char targetStr[50];                   ///< target postfix for the filename incase of multi positions
   int targetCount=0;                    ///< counts the number of targets user specified
-  ecmdI2cBusSpeed_t busspeed = ECMD_I2C_BUSSPEED_400KHZ; ///< bus speed to run i2c in khz
+  ecmdI2cBusSpeed_t busspeed = ECMD_I2C_BUSSPEED_UNKNOWN; ///< bus speed to run i2c in khz, let plugins choose default
+  uint32_t i2cFlags = 0x0;              ///< flags to be passed to the i2c driver where appropriate
   /************************************************************************/
   /* Parse Local FLAGS here!                                              */
   /************************************************************************/
@@ -96,6 +97,14 @@ uint32_t ecmdGetI2cUser(int argc, char * argv[]) {
     return ECMD_INVALID_ARGS;
   } 
   
+  char *tmpI2cFlags = ecmdParseOptionWithArgs(&argc, &argv, "-i2cflags"); 
+  if (!ecmdIsAllHex(tmpI2cFlags)) {
+    ecmdOutputError("geti2c - Non-hex characters detected in i2cflags field\n");
+    return ECMD_INVALID_ARGS;
+  } else if (tmpI2cFlags != NULL) {
+    i2cFlags = ecmdGenB32FromHexRight( &i2cFlags, tmpI2cFlags );
+  } 
+
   /* get the bus speed, if it's there */
   char * busspeedstr = ecmdParseOptionWithArgs(&argc, &argv, "-busspeed");
   if (busspeedstr != NULL) {
@@ -103,8 +112,12 @@ uint32_t ecmdGetI2cUser(int argc, char * argv[]) {
       busspeed = ECMD_I2C_BUSSPEED_50KHZ;
     } else if (strcmp(busspeedstr, "100")==0) {
       busspeed = ECMD_I2C_BUSSPEED_100KHZ;
-    } else if (strcmp(busspeedstr, "400")!=0) {
-      printed = "geti2c - Invalid value for busspeed. Possible values are - 400, 100, 50.\n";
+    } else if (strcmp(busspeedstr, "400")==0) {
+      busspeed = ECMD_I2C_BUSSPEED_400KHZ;
+    } else if (strcmp(busspeedstr, "1000")==0) {
+      busspeed = ECMD_I2C_BUSSPEED_1MHZ;
+    } else {
+      printed = "geti2c - Invalid value for busspeed. Possible values are - 1000, 400, 100, 50.\n";
       ecmdOutputError(printed.c_str());
       return ECMD_INVALID_ARGS;
     }
@@ -220,9 +233,9 @@ uint32_t ecmdGetI2cUser(int argc, char * argv[]) {
   while ( ecmdLooperNext(target1, looperdata1)&& (!coeRc || coeMode)) {
 
     if (argc > 5) {
-      rc = ecmdI2cReadOffset(target1, engineId, port, slaveAddr, busspeed , offset, fieldSize, numBytes, data);
+      rc = ecmdI2cReadOffset(target1, engineId, port, slaveAddr, busspeed , offset, fieldSize, numBytes, data, i2cFlags);
     } else {
-      rc = ecmdI2cRead(target1, engineId, port, slaveAddr, busspeed, numBytes, data);
+      rc = ecmdI2cRead(target1, engineId, port, slaveAddr, busspeed, numBytes, data, i2cFlags);
     }
     if (rc) { 
       if (argc > 5) {
@@ -284,7 +297,8 @@ uint32_t ecmdPutI2cUser(int argc, char * argv[]) {
   ecmdDataBuffer data;                  ///< buffer for the Data to write into the module vpd keyword
   bool validPosFound = false;           ///< Did the looper find anything to execute on
   bool inputformatflag = false;
-  ecmdI2cBusSpeed_t busspeed = ECMD_I2C_BUSSPEED_400KHZ; ///< bus speed to run i2c in khz
+  ecmdI2cBusSpeed_t busspeed = ECMD_I2C_BUSSPEED_UNKNOWN; ///< bus speed to run i2c in khz, let plugins choose default
+  uint32_t i2cFlags = 0x0;              ///< flags to be passed to the i2c driver where appropriate
   std::string printed;
   /************************************************************************/
   /* Parse Local FLAGS here!                                              */
@@ -297,7 +311,14 @@ uint32_t ecmdPutI2cUser(int argc, char * argv[]) {
     inputformatflag = true;
   }
   
-  
+  char *tmpI2cFlags = ecmdParseOptionWithArgs(&argc, &argv, "-i2cflags"); 
+  if (!ecmdIsAllHex(tmpI2cFlags)) {
+    ecmdOutputError("puti2c - Non-hex characters detected in i2cflags field\n");
+    return ECMD_INVALID_ARGS;
+  } else if (tmpI2cFlags != NULL) {
+    i2cFlags = ecmdGenB32FromHexRight( &i2cFlags, tmpI2cFlags );
+  }
+
   /* get the bus speed, if it's there */
   char * busspeedstr = ecmdParseOptionWithArgs(&argc, &argv, "-busspeed");
   if (busspeedstr != NULL) {
@@ -305,8 +326,12 @@ uint32_t ecmdPutI2cUser(int argc, char * argv[]) {
       busspeed = ECMD_I2C_BUSSPEED_50KHZ;
     } else if (strcmp(busspeedstr, "100")==0) {
       busspeed = ECMD_I2C_BUSSPEED_100KHZ;
-    } else if (strcmp(busspeedstr, "400")!=0) {
-      printed = "puti2c - Invalid value for busspeed. Possible values are - 400, 100, 50.\n";
+    } else if (strcmp(busspeedstr, "400")==0) {
+      busspeed = ECMD_I2C_BUSSPEED_400KHZ;
+    } else if (strcmp(busspeedstr, "1000")==0) {
+      busspeed = ECMD_I2C_BUSSPEED_1MHZ;
+    } else {
+      printed = "puti2c - Invalid value for busspeed. Possible values are - 1000, 400, 100, 50.\n";
       ecmdOutputError(printed.c_str());
       return ECMD_INVALID_ARGS;
     }
@@ -441,9 +466,9 @@ uint32_t ecmdPutI2cUser(int argc, char * argv[]) {
   while (ecmdLooperNext(target, looperdata) && (!coeRc || coeMode)) {
 
     if (((filename != NULL) && (argc > 4)) || ((filename == NULL) && (argc > 5))) {
-      rc = ecmdI2cWriteOffset(target, engineId, port, slaveAddr, busspeed , offset, fieldSize, data);
+      rc = ecmdI2cWriteOffset(target, engineId, port, slaveAddr, busspeed , offset, fieldSize, data, i2cFlags);
     } else {
-      rc = ecmdI2cWrite(target, engineId, port, slaveAddr, busspeed, data);
+      rc = ecmdI2cWrite(target, engineId, port, slaveAddr, busspeed, data, i2cFlags);
     }
     if (rc) {
       if (((filename != NULL) && (argc > 4)) || ((filename == NULL) && (argc > 5))) {
@@ -580,8 +605,16 @@ uint32_t getI2cMultipleParser(int & argc,char * argv[],ecmdI2CCmdEntry & o_cmd){
 
   uint32_t rc = ECMD_SUCCESS;
 
+  char *tmpI2cFlags = ecmdParseOptionWithArgs(&argc, &argv, "-i2cflags"); 
+  if (!ecmdIsAllHex(tmpI2cFlags)) {
+    ecmdOutputError("geti2cMultipleParser - Non-hex characters detected in i2cflags field\n");
+    return ECMD_INVALID_ARGS;
+  } else if (tmpI2cFlags != NULL) {
+    o_cmd.i2cFlags = ecmdGenB32FromHexRight( &o_cmd.i2cFlags, tmpI2cFlags );
+  } 
+
   std::string printed;
-  o_cmd.busSpeed = ECMD_I2C_BUSSPEED_400KHZ; //bus speed to run i2c in khz.This is default if not specified on cmdLine
+  o_cmd.busSpeed = ECMD_I2C_BUSSPEED_UNKNOWN; //bus speed to run i2c in khz.This is default if not specified on cmdLine, plugins will supply valid default
   // get the bus speed, if it's there 
   char * busspeedstr = ecmdParseOptionWithArgs(&argc, &argv, "-busspeed");
   if (busspeedstr != NULL) {
@@ -589,8 +622,12 @@ uint32_t getI2cMultipleParser(int & argc,char * argv[],ecmdI2CCmdEntry & o_cmd){
       o_cmd.busSpeed = ECMD_I2C_BUSSPEED_50KHZ;
     } else if (strcmp(busspeedstr, "100")==0) {
       o_cmd.busSpeed = ECMD_I2C_BUSSPEED_100KHZ;
-    } else if (strcmp(busspeedstr, "400")!=0) {
-      printed = "getI2cMultipleParser - Invalid value for busspeed. Possible values are - 400, 100, 50.\n";
+    } else if (strcmp(busspeedstr, "400")==0) {
+      o_cmd.busSpeed = ECMD_I2C_BUSSPEED_400KHZ;
+    } else if (strcmp(busspeedstr, "1000")==0) {
+      o_cmd.busSpeed = ECMD_I2C_BUSSPEED_1MHZ;
+    } else {
+      printed = "getI2cMultipleParser - Invalid value for busspeed. Possible values are - 1000, 400, 100, 50.\n";
       ecmdOutputError(printed.c_str());
       return ECMD_INVALID_ARGS;
     }
@@ -688,7 +725,15 @@ uint32_t putI2cMultipleParser(int & argc,char * argv[],ecmdI2CCmdEntry & o_cmd){
     inputformat = formatPtr;
   }
   
-  o_cmd.busSpeed = ECMD_I2C_BUSSPEED_400KHZ; // bus speed to run i2c in khz.This is default if not specified on cmdLine 
+  char *tmpI2cFlags = ecmdParseOptionWithArgs(&argc, &argv, "-i2cflags"); 
+  if (!ecmdIsAllHex(tmpI2cFlags)) {
+    ecmdOutputError("puti2cMultipleParser - Non-hex characters detected in i2cflags field\n");
+    return ECMD_INVALID_ARGS;
+  } else if (tmpI2cFlags != NULL) {
+    o_cmd.i2cFlags = ecmdGenB32FromHexRight( &o_cmd.i2cFlags, tmpI2cFlags );
+  } 
+
+  o_cmd.busSpeed = ECMD_I2C_BUSSPEED_UNKNOWN; // bus speed to run i2c in khz.This is default if not specified on cmdLine, plugins will set the default 
   // get the bus speed, if it's there 
   char * busspeedstr = ecmdParseOptionWithArgs(&argc, &argv, "-busspeed");
   if (busspeedstr != NULL) {
@@ -696,7 +741,11 @@ uint32_t putI2cMultipleParser(int & argc,char * argv[],ecmdI2CCmdEntry & o_cmd){
       o_cmd.busSpeed = ECMD_I2C_BUSSPEED_50KHZ;
     } else if (strcmp(busspeedstr, "100")==0) {
       o_cmd.busSpeed = ECMD_I2C_BUSSPEED_100KHZ;
-    } else if (strcmp(busspeedstr, "400")!=0) {
+    } else if (strcmp(busspeedstr, "400")==0) {
+      o_cmd.busSpeed = ECMD_I2C_BUSSPEED_400KHZ;
+    } else if (strcmp(busspeedstr, "1000")==0) {
+      o_cmd.busSpeed = ECMD_I2C_BUSSPEED_1MHZ;
+    } else {
       printed = "putI2cMultipleParser - Invalid value for busspeed. Possible values are - 400, 100, 50.\n";
       ecmdOutputError(printed.c_str());
       return ECMD_INVALID_ARGS;

--- a/ecmd-core/cmd/help/geti2c.htxt
+++ b/ecmd-core/cmd/help/geti2c.htxt
@@ -1,9 +1,9 @@
 
 Syntax: 
         WITHOUT OFFSET:
-        geti2c <Chip> <EngineId> <Port> <SlaveAddress> <Bytes> [-o<format> | -f<filename>] [-busspeed <speed>]
+        geti2c <Chip> <EngineId> <Port> <SlaveAddress> <Bytes> [-o<format> | -f<filename>] [-busspeed <speed>] [-i2cflags <flags>]
         WITH OFFSET:
-        geti2c <Chip> <EngineId> <Port> <SlaveAddress> <Bytes> <Offset> <FieldSize> [-o<format> | -f<filename>] [-busspeed <speed>]
+        geti2c <Chip> <EngineId> <Port> <SlaveAddress> <Bytes> <Offset> <FieldSize> [-o<format> | -f<filename>] [-busspeed <speed>] [-i2cflags <flags>]
         [-quiet] [-quieterror] [-exist] [-coe] [-a#] [-k#] [-n#] [-s#] [-p#]
 
         ECMD:           Core Common Function
@@ -31,8 +31,10 @@ Syntax:
 
         FieldSize       Byte width of the offset
 
-        -busspeed [opt] Specifies the bus speed to run i2c in khz : default 400
-                        Valid values are 400, 100, 50
+        -busspeed [opt] Specifies the bus speed to run i2c in khz : default set by plugin
+                        Valid values are 1000, 400, 100, 50
+
+        -i2cflags       Specifies the i2c flags to be passed in to the plugin
 
         -o<format>[opt] Specifies the format type of the output : default 'xl'
                         Run 'ecmdquery formats' to view available formats

--- a/ecmd-core/cmd/help/puti2c.htxt
+++ b/ecmd-core/cmd/help/puti2c.htxt
@@ -2,13 +2,13 @@
 Syntax: 
         WITHOUT OFFSET:
         puti2c <Chip> <EngineId> <Port> <SlaveAddress> <Data>
-                         [-coe] [-a#] [-k#] [-n#] [-s#] [-p#] [-i<format>] [-busspeed <speed>]
+                         [-coe] [-a#] [-k#] [-n#] [-s#] [-p#] [-i<format>] [-busspeed <speed>] [-i2cflags <flags>]
         puti2c <Chip> <EngineId> <Port> <SlaveAddress> -f<filename>
-                         [-coe] [-a#] [-k#] [-n#] [-s#] [-p#] [-busspeed <speed>]
+                         [-coe] [-a#] [-k#] [-n#] [-s#] [-p#] [-busspeed <speed>] [-i2cflags <flags>]
 
         WITH OFFSET:
-        puti2c <Chip> <EngineId> <Port> <SlaveAddress> <Data> <Offset> <FieldSize> [-i<format>] [-busspeed <speed>]
-        puti2c <Chip> <EngineId> <Port> <SlaveAddress> -f<filename> <Offset> <FieldSize> [-busspeed <speed>]
+        puti2c <Chip> <EngineId> <Port> <SlaveAddress> <Data> <Offset> <FieldSize> [-i<format>] [-busspeed <speed>] [-i2cflags <flags>]
+        puti2c <Chip> <EngineId> <Port> <SlaveAddress> -f<filename> <Offset> <FieldSize> [-busspeed <speed>] [-i2cflags <flags>]
         [-quiet] [-quieterror] [-exist] [-coe] [-a#] [-k#] [-n#] [-s#] [-p#]
 
         ECMD:           Core Common Function
@@ -35,8 +35,10 @@ Syntax:
 
         FieldSize       Byte width of the offset
 
-        -busspeed [opt] Specifies the bus speed to run i2c in khz : default 400
-                        Valid values are 400, 100, 50
+        -busspeed [opt] Specifies the bus speed to run i2c in khz : default set by plugin
+                        Valid values are 1000, 400, 100, 50
+
+        -i2cflags       Specifies the i2c flags to be passed in to the plugin
 
         -i<format>[opt] Specifies the format type of the input : default 'xl'
                         Run 'ecmdquery formats' to view available formats

--- a/ecmd-core/pyapi/makefile
+++ b/ecmd-core/pyapi/makefile
@@ -81,7 +81,7 @@ pyapi_install:
 
 test:
 	@echo "***** If you see python load errors this build of the python module is invalid ****"
-	@ECMD_DLL_FILE=${OUTLIB}/stub.dll PYTHONPATH=${OUTPY} LD_LIBRARY_PATH=${OUTLIB}:${OUTPY} ${ECMDPYTHONBIN} ../pyapi/testBuild.py
+	${VERBOSE}ECMD_DLL_FILE=${OUTLIB}/stub.dll PYTHONPATH=${OUTPY} LD_LIBRARY_PATH=${OUTLIB}:${OUTPY} ${ECMDPYTHONBIN} ../pyapi/testBuild.py
 
 doxygen-pyapi:
 	@cp ecmdPyApiTypes.H ${DOXYGEN_PERLAPI_PATH}/.


### PR DESCRIPTION
…river or plugin.

Change default busspeed to unknown so plugin can set appropriate default.  Affects cases where we need to know something was specified on the command line vs just being set.

Signed-off-by: Steven Janssen <janssens@us.ibm.com>