### PR TITLE
Fix format security in eCMD

### DIFF
--- a/dllNetwork/server/ServerFSIInstruction.C
+++ b/dllNetwork/server/ServerFSIInstruction.C
@@ -248,7 +248,7 @@ uint32_t ServerFSIInstruction::mbx_open(Handle** handle, InstructionStatus & o_s
 
   for (uint32_t l_try = 0; l_try < numPaths; l_try++) {
     /* Validate and adjust the device string for the device to open */
-    snprintf(device, 100, devices[l_idx][l_try]);
+    snprintf(device, 100, "%s", devices[l_idx][l_try]);
     if ( strlen(device) == 0 ) continue;
 
     errno = 0;


### PR DESCRIPTION
eCMD appears to have one snprintf violation that prevents it from
compiling with -fformat-security enabled.  This patch corrects this
error, and allows compiling with the aforementioned flag.

This was found as part of attempting to enable the -fformat-security
flag on OpenBMC.

https://gerrit.openbmc-project.xyz/c/openbmc/meta-phosphor/+/39481

Signed-off-by: Ed Tanous <ed@tanous.net>