### PR TITLE
2 updates to the ecmdsetup process

### DIFF
--- a/ecmd-core/bin/ecmdsetup.pl
+++ b/ecmd-core/bin/ecmdsetup.pl
@@ -383,9 +383,9 @@ sub main {
   }
 
   ##########################################################################
-  # If release was set to rel by plugin setup, change local variable
+  # If release was set by plugin setup, change local variable
   #
-  if ($ENV{"ECMD_RELEASE"} eq "rel") {
+  if ($modified{"ECMD_RELEASE"} == 1) {
     $release = $ENV{"ECMD_RELEASE"};
   }
 
@@ -419,10 +419,10 @@ sub main {
   }
 
   ##########################################################################
-  # Change shared lib path to point to release for cronus
+  # Change shared lib path to point to release
   # This is because the release may have changed from the installPath that was used
   #
-  if ((!$cleanup) && ($plugin eq "cro") && (!$singleInstall)) {
+  if ((!$cleanup) && (!$singleInstall)) {
       my $sharedLib;
       if ($arch =~ m/aix/) {
           $sharedLib = "LIBPATH";


### PR DESCRIPTION
- Removed cronus specific reference that can be generically
  applied to any plugin
- Made specific case allowing the plugin to set ECMD_RELEASE
  more general.

  Previously, if the plugin set ECMD_RELEASE to "rel", the top
  level setup code would honor and use that.  Anything else was
  discarded though.  Now, if the plugin indicates it has changed
  the ECMD_RELEASE, the top level script will use that.

Signed-off-by: Jason Albert <albertj@us.ibm.com>