### PR TITLE
ecmdsetup singleInstall update

### DIFF
--- a/ecmd-core/bin/ecmdsetup.pl
+++ b/ecmd-core/bin/ecmdsetup.pl
@@ -422,7 +422,7 @@ sub main {
   # Change shared lib path to point to release
   # This is because the release may have changed from the installPath that was used
   #
-  if ((!$cleanup) && (!$singleInstall)) {
+  if (!$cleanup) {
       my $sharedLib;
       if ($arch =~ m/aix/) {
           $sharedLib = "LIBPATH";


### PR DESCRIPTION
The singleInstall condition didn't seem necessary and was causing
the shared lib path to not be setup

Signed-off-by: Jason Albert <albertj@us.ibm.com>