### PR TITLE
Remove fapiClientCapi.C reference from perl/python makefiles since it…

### DIFF
--- a/ecmd-core/perlapi/makefile
+++ b/ecmd-core/perlapi/makefile
@@ -44,9 +44,8 @@ VPATH    := ${VPATH}:${ECMD_CORE}/capi:${SRCPATH}:distro/${INC_DISTRO}:${OBJPATH
 ### Add all of the extension information onto our variables
 INCLUDES  := ${INCLUDES} $(foreach ext, ${EXT_PYAPI}, ${ext}ClientPerlapi.H ${ext}ClientCapi.H)
 SOURCE    := ${SOURCE} $(foreach ext, ${EXT_PYAPI}, ${ext}ClientPerlapi.C ${ext}ClientPerlapiFunc.C)
-# Remove the fapiClientPerlapiFunc.C from the build, only will use fapiClientPerlapi.C which has the init extension
+# Remove the fapi2ClientPerlapiFunc.C from the build, only will use fapi2ClientPerlapi.C which has the init extension
 SOURCE    := $(subst fapi2ClientPerlapiFunc.C,,${SOURCE})
-SOURCE    := $(subst fapiClientPerlapiFunc.C,,${SOURCE})
 CXXFLAGS  := ${CXXFLAGS} $(foreach ext, ${EXT_PYAPI},-I${EXT_${ext}_PATH}/capi -I${EXT_${ext}_PATH}/perlapi)
 SWIGFLAGS := ${SWIGFLAGS} $(foreach ext, ${EXT_PYAPI},-I${EXT_${ext}_PATH}/perlapi -I${EXT_${ext}_PATH}/capi)
 VPATH     := ${VPATH}$(foreach ext, ${EXT_PYAPI},:${EXT_${ext}_PATH}/capi:${EXT_${ext}_PATH}/perlapi)

--- a/ecmd-core/pyapi/makefile
+++ b/ecmd-core/pyapi/makefile
@@ -32,8 +32,6 @@ VPATH    := ${VPATH}:${ECMD_CORE}/capi:${SRCPATH}:${OBJPATH}
 ### Add all of the extension information onto our variables
 INCLUDES  := ${INCLUDES} $(foreach ext, ${EXT_PYAPI}, ${ext}ClientCapi.H ${ext}ClientPyapi.H)
 SOURCE    := ${SOURCE} $(foreach ext, ${EXT_PYAPI}, ${ext}ClientCapi.C ${ext}ClientPyapi.C)
-# Remove the fapiClientCapi.C from the build, only will use fapiClientPyapi.C which has the init extension
-SOURCE    := $(subst fapiClientCapi.C,,${SOURCE})
 CXXFLAGS  := ${CXXFLAGS} $(foreach ext, ${EXT_PYAPI},-I${EXT_${ext}_PATH}/capi -I${EXT_${ext}_PATH}/pyapi)
 SWIGFLAGS := ${SWIGFLAGS} $(foreach ext, ${EXT_PYAPI},-I${EXT_${ext}_PATH}/capi -I${EXT_${ext}_PATH}/pyapi)
 VPATH     := ${VPATH}$(foreach ext, ${EXT_PYAPI},:${EXT_${ext}_PATH}/capi:${EXT_${ext}_PATH}/pyapi)


### PR DESCRIPTION
… doesn't exist anymore

Signed-off-by: Kahn Evans <kahnevan@us.ibm.com>