### PR TITLE
Fix config.py prompting incorrect options for Python include path

### DIFF
--- a/config.py
+++ b/config.py
@@ -779,13 +779,13 @@ if (PERLINC is not None):
 if (PYINC is not None):
     if (PYINC == ""):
         print("ERROR: Unable to determine path to python includes")
-        print("ERROR: Please install the python includes, specify the path via --pyinc or disable python module build")
+        print("ERROR: Please install the python includes, specify the path via --pythoninc or disable python module build")
         sys.exit(1)
     buildvars["PYINC"] = PYINC
 if (PY3INC is not None):
     if (PY3INC == ""):
         print("ERROR: Unable to determine path to python3 includes")
-        print("ERROR: Please install the python3 includes, specify the path via --py3inc or disable python3 module build")
+        print("ERROR: Please install the python3 includes, specify the path via --python3inc or disable python3 module build")
         sys.exit(1)
     buildvars["PY3INC"] = PY3INC
 


### PR DESCRIPTION
`config.py` suggests option `--pyinc` when it can't determine the include path for Python 2, for example:
```
whr@debian:~/src/eCMD$ python3 config.py --build-verbose 
Establishing eCMD build variables..
Determining host and distro..
Establishing output locations..
Establishing compiler locations..
Establishing compiler options..
Finding swig include files..
ERROR: Unable to determine path to python includes
ERROR: Please install the python includes, specify the path via --pyinc or disable python module build
whr@debian:~/src/eCMD$ python3 config.py --build-verbose --pyinc /opt/python2.7/include/python2.7
usage: config.py [-h] [--install-path INSTALL_PATH] [--host HOST]
                 [--target TARGET] [--cxx CXX] [--cxx_r CXX_R]
                 [--cxxflags CXXFLAGS] [--firstinc FIRSTINC]
                 [--header-defines] [--ld LD] [--ld_r LD_R] [--ar AR]
                 [--sysroot SYSROOT] [--swig SWIG] [--perl PERL]
                 [--perlinc PERLINC] [--python PYTHON] [--pythoninc PYTHONINC]
                 [--python3 PYTHON3] [--python3inc PYTHON3INC]
                 [--catchinc CATCHINC] [--doxygen DOXYGEN]
                 [--output-root OUTPUT_ROOT] [--extensions EXTENSIONS]
                 [--ecmd-repos ECMD_REPOS] [--remove-sim] [--without-swig]
                 [--without-perl] [--without-python] [--without-python3]
                 [--without-pyecmd] [--build-disable-test] [--build-verbose]
config.py: error: unrecognized arguments: --pyinc /opt/python2.7/include/python2.7
```
The correct option however, is `--pythoninc`.

Similarly for Python 3:
```
whr@debian:~/src/eCMD$ python3 config.py --build-verbose --without-python
Establishing eCMD build variables..
Determining host and distro..
Establishing output locations..
Establishing compiler locations..
Establishing compiler options..
Finding swig include files..
ERROR: Unable to determine path to python3 includes
ERROR: Please install the python3 includes, specify the path via --py3inc or disable python3 module build
whr@debian:~/src/eCMD$ python3 config.py --build-verbose --without-python --py3inc /usr/local/include/python3.6
usage: config.py [-h] [--install-path INSTALL_PATH] [--host HOST]
                 [--target TARGET] [--cxx CXX] [--cxx_r CXX_R]
                 [--cxxflags CXXFLAGS] [--firstinc FIRSTINC]
                 [--header-defines] [--ld LD] [--ld_r LD_R] [--ar AR]
                 [--sysroot SYSROOT] [--swig SWIG] [--perl PERL]
                 [--perlinc PERLINC] [--python PYTHON] [--pythoninc PYTHONINC]
                 [--python3 PYTHON3] [--python3inc PYTHON3INC]
                 [--catchinc CATCHINC] [--doxygen DOXYGEN]
                 [--output-root OUTPUT_ROOT] [--extensions EXTENSIONS]
                 [--ecmd-repos ECMD_REPOS] [--remove-sim] [--without-swig]
                 [--without-perl] [--without-python] [--without-python3]
                 [--without-pyecmd] [--build-disable-test] [--build-verbose]
config.py: error: unrecognized arguments: --py3inc /usr/local/include/python3.6
```