### PR TITLE
getscom -call to sort the cores numerically

### DIFF
--- a/ecmd-core/dll/ecmdDllCapi.C
+++ b/ecmd-core/dll/ecmdDllCapi.C
@@ -384,6 +384,13 @@ bool dllQueryVersionGreater(const char* version) {
   return false;
 }
 
+/*Compares the Chipunit number and returns true 
+  if first ecmdChipUnitData has a lower ChipUnit Number*/
+bool compareChipUnitNum(ecmdChipUnitData a, ecmdChipUnitData b)
+{
+  return a.chipUnitNum < b.chipUnitNum;
+}
+
 void ecmdIncrementLooperIterators (uint8_t level, ecmdLooperData& io_state);
 
 // dllConfigLooperInit and dllExistLooperInit just call dllLooperInit in the correct mode
@@ -1907,6 +1914,8 @@ uint32_t queryConfigExistSelected(ecmdChipTarget & i_target, ecmdQueryData & o_q
             }
           }
 
+          /* sort the chipUnits based on the chip unit numbers*/ 
+          curChip->chipUnitData.sort(compareChipUnitNum);
           /* Walk through all the chipUnits */
           std::list<ecmdChipUnitData>::iterator curChipUnit = curChip->chipUnitData.begin();
           while (curChipUnit != curChip->chipUnitData.end()) {


### PR DESCRIPTION
    Earlier the display of the cores were arranged in alphabetical order which
is
    difficult to read.

    It is fixed with this commit to sort numerically

    Earlier :
    getscom pu.perv 000F0040 -p0 -call
    pu.perv k0:n0:s0:p00:c1    0x7EC6FF807EC6FF04
    pu.perv k0:n0:s0:p00:c12   0xA020000100000000
    pu.perv k0:n0:s0:p00:c13   0xA020000100000000
    pu.perv k0:n0:s0:p00:c14   0x0000000000000000
    pu.perv k0:n0:s0:p00:c15   0x0000000000000000
    pu.perv k0:n0:s0:p00:c16   0x9C20000000000000
    pu.perv k0:n0:s0:p00:c17   0x9C20000000000000
    pu.perv k0:n0:s0:p00:c18   0x9C20000000000000
    pu.perv k0:n0:s0:p00:c19   0x9C20000000000000
    pu.perv k0:n0:s0:p00:c2    0x9C201C0000000000
    pu.perv k0:n0:s0:p00:c24   0x0000000000000000
    pu.perv k0:n0:s0:p00:c25   0x0000000000000000
    pu.perv k0:n0:s0:p00:c26   0xA020000100000000
    pu.perv k0:n0:s0:p00:c27   0xA020000100000000
    pu.perv k0:n0:s0:p00:c28   0xA020000100000000
    pu.perv k0:n0:s0:p00:c29   0x0000000000000000
    pu.perv k0:n0:s0:p00:c3    0x9C201C0000000000
    pu.perv k0:n0:s0:p00:c30   0xA020000100000000
    pu.perv k0:n0:s0:p00:c31   0xA020000100000000
    pu.perv k0:n0:s0:p00:c32   0xBC20000000000000
    pu.perv k0:n0:s0:p00:c33   0xBC20000000000000
    pu.perv k0:n0:s0:p00:c34   0xBC20000000000000
    pu.perv k0:n0:s0:p00:c35   0xBC20000000000000
    pu.perv k0:n0:s0:p00:c36   0xBC20000000000000
    pu.perv k0:n0:s0:p00:c37   0xBC20000000000000
    pu.perv k0:n0:s0:p00:c38   0xBC20000000000000
    pu.perv k0:n0:s0:p00:c39   0xBC20000000000000
    pu.perv k0:n0:s0:p00:c8    0x8020000100000000
    pu.perv k0:n0:s0:p00:c9    0x8020000100000000
    /usr/bin/edbg getscom pu.perv 000F0040 -p0 -call

    Now:
    bmc:~# getscom pu.perv 000F0040 -p0 -call
    pu.perv k0:n0:s0:p00:c2    0x9C201C0000000000
    pu.perv k0:n0:s0:p00:c3    0x9C201C0000000000
    pu.perv k0:n0:s0:p00:c8    0x8020000100000000
    pu.perv k0:n0:s0:p00:c9    0x8020000100000000
    pu.perv k0:n0:s0:p00:c12   0xA020000100000000
    pu.perv k0:n0:s0:p00:c13   0xA020000100000000
    pu.perv k0:n0:s0:p00:c16   0x9C20000000000000
    pu.perv k0:n0:s0:p00:c17   0x9C20000000000000
    pu.perv k0:n0:s0:p00:c18   0x9C20000000000000
    pu.perv k0:n0:s0:p00:c19   0x9C20000000000000
    pu.perv k0:n0:s0:p00:c26   0xA020000100000000
    pu.perv k0:n0:s0:p00:c27   0xA020000100000000
    pu.perv k0:n0:s0:p00:c28   0xA020000100000000
    pu.perv k0:n0:s0:p00:c30   0xA020000100000000
    pu.perv k0:n0:s0:p00:c31   0xA020000100000000
    pu.perv k0:n0:s0:p00:c32   0xBC20000000000000
    pu.perv k0:n0:s0:p00:c33   0xBC20000000000000
    pu.perv k0:n0:s0:p00:c34   0xBC20000000000000
    pu.perv k0:n0:s0:p00:c35   0xBC20000000000000
    pu.perv k0:n0:s0:p00:c36   0xBC20000000000000
    pu.perv k0:n0:s0:p00:c37   0xBC20000000000000
    pu.perv k0:n0:s0:p00:c38   0xBC20000000000000
    pu.perv k0:n0:s0:p00:c39   0xBC20000000000000